### PR TITLE
sbt based project setup

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -37,8 +37,9 @@ object Dependencies {
   val slf4j = "org.slf4j" % "slf4j-api" % "1.7.12"
   val Log4JVersion = "2.6.2"
   val log4jCore = "org.apache.logging.log4j" % "log4j-core" % Log4JVersion
+  val log4jApi = "org.apache.logging.log4j" % "log4j-api" % Log4JVersion
   val log4jSlf4jImpl = "org.apache.logging.log4j" % "log4j-slf4j-impl" % Log4JVersion
-  val logging = Seq(slf4j, log4jCore, log4jSlf4jImpl)
+  val logging = Seq(slf4j, log4jCore, log4jApi, log4jSlf4jImpl)
 
   val rocksDB = "org.rocksdb" % "rocksdbjni" % "4.9.0"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,0 +1,46 @@
+import sbt._
+
+object Dependencies {
+  val scalatest = "org.scalatest" %% "scalatest" % "2.1.3" % "test"
+  val mockito = "org.mockito" % "mockito-core" % "1.10.19" % "test"
+
+  val test = Seq(scalatest, mockito)
+
+  val commonsIO = "commons-io" % "commons-io" % "2.4" % "compile"
+
+  val AtomixVersion = "1.0.0-rc9"
+  val atomixCore = "io.atomix" % "atomix" % AtomixVersion % "compile"
+  val atomixResource = "io.atomix" % "atomix-resource" % AtomixVersion % "compile"
+  val atomix = Seq(atomixCore, atomixResource)
+
+  val CatalystVersion = "1.1.1"
+  val catalystTransport = "io.atomix.catalyst" % "catalyst-transport" % CatalystVersion % "compile"
+  val catalystNetty = "io.atomix.catalyst" % "catalyst-netty" % CatalystVersion % "compile"
+  val catalyst = Seq(catalystTransport, catalystNetty)
+
+  val GrpcVersion = "1.0.1"
+  val grpcNetty = "io.grpc" % "grpc-netty" % GrpcVersion % "compile"
+  val grpcProtobuf = "io.grpc" % "grpc-protobuf" % GrpcVersion % "compile"
+  val grpcStub = "io.grpc" % "grpc-stub" % GrpcVersion % "compile"
+  val grpcServices = "io.grpc" % "grpc-services" % GrpcVersion % "compile"
+  val grpc = Seq(grpcNetty, grpcProtobuf, grpcStub, grpcServices)
+
+  val scalapbRuntime = "com.trueaccord.scalapb" %% "scalapb-runtime-grpc" % "0.5.42"
+
+  val NettyVersion = "4.1.3.Final"
+  val nettyCodec = "io.netty" % "netty-codec" % NettyVersion % "compile"
+  val nettyCommon = "io.netty" % "netty-common" % NettyVersion % "compile"
+  val nettyTransport = "io.netty" % "netty-transport" % NettyVersion % "compile"
+  val nettyHandler = "io.netty" % "netty-handler" % NettyVersion % "compile"
+  val netty = Seq(nettyCodec, nettyCommon, nettyTransport, nettyTransport)
+
+  val slf4j = "org.slf4j" % "slf4j-api" % "1.7.12" % "compile"
+  val Log4JVersion = "2.6.2"
+  val log4jCore = "org.apache.logging.log4j" % "log4j-core" % Log4JVersion % "compile"
+  val log4jSlf4jImpl = "org.apache.logging.log4j" % "log4j-slf4j-impl" % Log4JVersion % "compile"
+  val logging = Seq(slf4j, log4jCore, log4jSlf4jImpl)
+
+  val rocksDB = "org.rocksdb" % "rocksdbjni" % "4.9.0" % "compile"
+
+  val core = test ++ Seq(commonsIO, rocksDB, scalapbRuntime) ++ grpc ++ netty ++ logging ++ atomix ++ catalyst
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,41 +6,41 @@ object Dependencies {
 
   val test = Seq(scalatest, mockito)
 
-  val commonsIO = "commons-io" % "commons-io" % "2.4" % "compile"
+  val commonsIO = "commons-io" % "commons-io" % "2.4"
 
   val AtomixVersion = "1.0.0-rc9"
-  val atomixCore = "io.atomix" % "atomix" % AtomixVersion % "compile"
-  val atomixResource = "io.atomix" % "atomix-resource" % AtomixVersion % "compile"
+  val atomixCore = "io.atomix" % "atomix" % AtomixVersion
+  val atomixResource = "io.atomix" % "atomix-resource" % AtomixVersion
   val atomix = Seq(atomixCore, atomixResource)
 
   val CatalystVersion = "1.1.1"
-  val catalystTransport = "io.atomix.catalyst" % "catalyst-transport" % CatalystVersion % "compile"
-  val catalystNetty = "io.atomix.catalyst" % "catalyst-netty" % CatalystVersion % "compile"
+  val catalystTransport = "io.atomix.catalyst" % "catalyst-transport" % CatalystVersion
+  val catalystNetty = "io.atomix.catalyst" % "catalyst-netty" % CatalystVersion
   val catalyst = Seq(catalystTransport, catalystNetty)
 
   val GrpcVersion = "1.0.1"
-  val grpcNetty = "io.grpc" % "grpc-netty" % GrpcVersion % "compile"
-  val grpcProtobuf = "io.grpc" % "grpc-protobuf" % GrpcVersion % "compile"
-  val grpcStub = "io.grpc" % "grpc-stub" % GrpcVersion % "compile"
-  val grpcServices = "io.grpc" % "grpc-services" % GrpcVersion % "compile"
+  val grpcNetty = "io.grpc" % "grpc-netty" % GrpcVersion
+  val grpcProtobuf = "io.grpc" % "grpc-protobuf" % GrpcVersion
+  val grpcStub = "io.grpc" % "grpc-stub" % GrpcVersion
+  val grpcServices = "io.grpc" % "grpc-services" % GrpcVersion
   val grpc = Seq(grpcNetty, grpcProtobuf, grpcStub, grpcServices)
 
   val scalapbRuntime = "com.trueaccord.scalapb" %% "scalapb-runtime-grpc" % "0.5.42"
 
   val NettyVersion = "4.1.3.Final"
-  val nettyCodec = "io.netty" % "netty-codec" % NettyVersion % "compile"
-  val nettyCommon = "io.netty" % "netty-common" % NettyVersion % "compile"
-  val nettyTransport = "io.netty" % "netty-transport" % NettyVersion % "compile"
-  val nettyHandler = "io.netty" % "netty-handler" % NettyVersion % "compile"
+  val nettyCodec = "io.netty" % "netty-codec" % NettyVersion
+  val nettyCommon = "io.netty" % "netty-common" % NettyVersion
+  val nettyTransport = "io.netty" % "netty-transport" % NettyVersion
+  val nettyHandler = "io.netty" % "netty-handler" % NettyVersion
   val netty = Seq(nettyCodec, nettyCommon, nettyTransport, nettyTransport)
 
-  val slf4j = "org.slf4j" % "slf4j-api" % "1.7.12" % "compile"
+  val slf4j = "org.slf4j" % "slf4j-api" % "1.7.12"
   val Log4JVersion = "2.6.2"
-  val log4jCore = "org.apache.logging.log4j" % "log4j-core" % Log4JVersion % "compile"
-  val log4jSlf4jImpl = "org.apache.logging.log4j" % "log4j-slf4j-impl" % Log4JVersion % "compile"
+  val log4jCore = "org.apache.logging.log4j" % "log4j-core" % Log4JVersion
+  val log4jSlf4jImpl = "org.apache.logging.log4j" % "log4j-slf4j-impl" % Log4JVersion
   val logging = Seq(slf4j, log4jCore, log4jSlf4jImpl)
 
-  val rocksDB = "org.rocksdb" % "rocksdbjni" % "4.9.0" % "compile"
+  val rocksDB = "org.rocksdb" % "rocksdbjni" % "4.9.0"
 
   val core = test ++ Seq(commonsIO, rocksDB, scalapbRuntime) ++ grpc ++ netty ++ logging ++ atomix ++ catalyst
 }

--- a/project/OSDetector.scala
+++ b/project/OSDetector.scala
@@ -1,0 +1,19 @@
+import java.util.Collections
+
+import kr.motd.maven.os.Detector
+
+object OSDetector {
+  private val impl = new Detector {
+    val detectedProperties = System.getProperties
+
+    detect(detectedProperties, Collections.emptyList())
+    override def log(s: String): Unit = {}
+    override def logProperty(s: String, s1: String): Unit = {}
+  }
+
+  def getClassifier = impl.detectedProperties.getProperty(Detector.DETECTED_CLASSIFIER)
+
+  def getOs = impl.detectedProperties.getProperty(Detector.DETECTED_NAME)
+
+  def getArch = impl.detectedProperties.get(Detector.DETECTED_ARCH)
+}

--- a/project/SbtGrpcJava.scala
+++ b/project/SbtGrpcJava.scala
@@ -6,6 +6,7 @@ import sbt._
 import sbtprotoc.ProtocPlugin.autoImport.PB
 
 object SbtGrpcJava {
+  val log = MainLogging.defaultScreen(ConsoleOut.systemOut)
 
   def protobufSettings(moduleName: String) = Seq(
     PB.protoSources in Compile := Seq(file(s"$moduleName/src/main/proto")),
@@ -31,7 +32,7 @@ object SbtGrpcJava {
     if (!outputFile.exists()) {
       downloadPlugin(version, fileName, outputFile)
     } else {
-      println("GRPC Plugin found locally")
+      log.success("protoc-grpc-plugin found locally at " + outputFile.getAbsolutePath)
     }
     outputFile.setExecutable(true) // explicitly mark the file executable
     outputFile.getAbsolutePath
@@ -40,9 +41,9 @@ object SbtGrpcJava {
   def downloadPlugin(version: String, fileName: String, outputFile: File): Unit = {
     val binaryUrl = sbt.url("http://repo1.maven.org/maven2/io/grpc/protoc-gen-grpc-java/" + version + "/" + fileName)
     val outputStream = new FileOutputStream(outputFile)
-    println("Downloading " + binaryUrl.toString + " to " + outputFile.getAbsolutePath)
+    log.info("Downloading " + binaryUrl.toString + " to " + outputFile.getAbsolutePath)
     IOUtils.copy(binaryUrl.openConnection().getInputStream, outputStream)
     IOUtils.closeQuietly(outputStream)
-    println("Download of protoc-gen-grpc-java plugin is complete")
+    log.success("Download of protoc-gen-grpc-java plugin is complete")
   }
 }

--- a/project/SbtGrpcJava.scala
+++ b/project/SbtGrpcJava.scala
@@ -1,0 +1,48 @@
+import java.io.{File, FileOutputStream}
+
+import org.apache.commons.io.IOUtils
+import sbt.Keys._
+import sbt._
+import sbtprotoc.ProtocPlugin.autoImport.PB
+
+object SbtGrpcJava {
+
+  def protobufSettings(moduleName: String) = Seq(
+    PB.protoSources in Compile := Seq(file(s"$moduleName/src/main/proto")),
+    PB.targets in Compile := Seq(
+      PB.gens.java -> (sourceManaged in Compile).value // disable
+    ),
+    PB.protocOptions in Compile := Seq(
+      "--plugin=protoc-gen-grpc-java=" + pluginPath(targetPath = (target in Compile).value.getAbsolutePath),
+      "--grpc-java_out=" + (sourceManaged in Compile).value.getAbsolutePath
+    )
+  )
+
+  /**
+   * Downloads the protoc-grpc-plugin if not found locally and returns the path
+   *
+   * TODO - Extract this as an SBT plugin and release it
+   */
+  def pluginPath(targetPath: String, version: String = "1.0.1"): String = {
+    val osClassifier = OSDetector.getClassifier
+    val fileName = "protoc-gen-grpc-java-" + version + "-" + osClassifier + ".exe"
+    val outputFile = new File(targetPath + "/protoc-plugins/" + fileName)
+    outputFile.getParentFile.mkdirs()
+    if (!outputFile.exists()) {
+      downloadPlugin(version, fileName, outputFile)
+    } else {
+      println("GRPC Plugin found locally")
+    }
+    outputFile.setExecutable(true) // explicitly mark the file executable
+    outputFile.getAbsolutePath
+  }
+
+  def downloadPlugin(version: String, fileName: String, outputFile: File): Unit = {
+    val binaryUrl = sbt.url("http://repo1.maven.org/maven2/io/grpc/protoc-gen-grpc-java/" + version + "/" + fileName)
+    val outputStream = new FileOutputStream(outputFile)
+    println("Downloading " + binaryUrl.toString + " to " + outputFile.getAbsolutePath)
+    IOUtils.copy(binaryUrl.openConnection().getInputStream, outputStream)
+    IOUtils.closeQuietly(outputStream)
+    println("Download of protoc-gen-grpc-java plugin is complete")
+  }
+}

--- a/project/SuuchiBuild.scala
+++ b/project/SuuchiBuild.scala
@@ -1,0 +1,64 @@
+import sbt.Keys._
+import sbt._
+
+object SuuchiBuild extends Build {
+
+  val AppVersion = "0.1-SNAPSHOT"
+  val ScalaVersion = "2.10.6"
+
+  lazy val suuchi = Project("suuchi", file("."), settings = defaultSettings)
+    .settings(organization := "in.ashwanthkumar",
+      version := AppVersion,
+      libraryDependencies ++= Dependencies.core
+    ).settings(
+    SbtGrpcJava.protobufSettings("."): _*
+  )
+
+
+  lazy val defaultSettings = super.settings ++ Seq(
+    fork in run := false,
+    parallelExecution in This := false,
+    publishMavenStyle := true,
+    publishArtifact in Test := false,
+    publishArtifact in(Compile, packageDoc) := true,
+    publishArtifact in(Compile, packageSrc) := true,
+    resolvers += "Local Maven Repository" at "file://" + Path.userHome.absolutePath + "/.m2/repository",
+    resolvers += "Typesafe Releases" at "http://repo.typesafe.com/typesafe/releases/",
+    publishTo <<= version { (v: String) =>
+      val nexus = "https://oss.sonatype.org/"
+      if (v.trim.endsWith("SNAPSHOT"))
+        Some("snapshots" at nexus + "content/repositories/snapshots")
+      else
+        Some("releases" at nexus + "service/local/staging/deploy/maven2")
+    },
+    pomExtra := _pomExtra
+  )
+
+  val _pomExtra =
+    <description>Toolkit to build distributed Data Systems</description>
+      <url>https://github.com/ashwanthkumar/suuchi</url>
+      <licenses>
+        <license>
+          <name>Apache2</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+        </license>
+      </licenses>
+      <scm>
+        <url>https://github.com/ashwanthkumar/suuchi</url>
+        <connection>scm:git:git@github.com:ashwanthkumar/suuchi.git</connection>
+      </scm>
+      <developers>
+        <developer>
+          <email>ashwanthkumar@googlemail.com</email>
+          <name>Ashwanth Kumar</name>
+          <url>https://ashwanthkumar.in/</url>
+          <id>ashwanthkumar</id>
+        </developer>
+        <developer>
+          <email>sri.rams85@gmail.com</email>
+          <name>Sriram Ramachandrasekaran</name>
+          <id>brewkode</id>
+        </developer>
+      </developers>
+
+}

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.12

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,2 @@
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.3.5")
+

--- a/project/protoc.sbt
+++ b/project/protoc.sbt
@@ -1,0 +1,6 @@
+addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.1")
+
+libraryDependencies += "commons-io" % "commons-io" % "2.4"
+
+// sbt couldn't seem to pick this artifact unless explicitly added from the url - :-/
+libraryDependencies += "kr.motd.maven" % "os-maven-plugin" % "1.4.0.Final" from "http://central.maven.org/maven2/kr/motd/maven/os-maven-plugin/1.4.0.Final/os-maven-plugin-1.4.0.Final.jar"


### PR DESCRIPTION
Had to write a lot of boiler plate around protobuf - grpc integration if we don't want to change a lot of things.

I saw [ScalaPB](https://trueaccord.github.io/ScalaPB/grpc.html) but didn't want to generate Scala based classes for the default set of services - at least not yet. So I wrote a wrapper in the build to download the official protoc-grpc-java plugin and execute it as part of the `sbt compile` phase.

As noted the `SbtGrpcJava` part should be extracted into a SBT plugin on it's own so folks who don't want to use ScalaPB still has a choice to use the default Java based Services and proto messages.
