### PR TITLE
Pluggable Replicator

### DIFF
--- a/src/main/scala/in/ashwanthkumar/suuchi/client/SuuchiClient.scala
+++ b/src/main/scala/in/ashwanthkumar/suuchi/client/SuuchiClient.scala
@@ -1,6 +1,5 @@
 package in.ashwanthkumar.suuchi.client
 
-import java.lang.{String => JString}
 import java.util.concurrent.TimeUnit
 
 import com.google.protobuf.ByteString

--- a/src/main/scala/in/ashwanthkumar/suuchi/example/DistributedRocksDb.scala
+++ b/src/main/scala/in/ashwanthkumar/suuchi/example/DistributedRocksDb.scala
@@ -1,16 +1,12 @@
 package in.ashwanthkumar.suuchi.example
 
-import java.io.File
 import java.nio.file.Files
 
-import in.ashwanthkumar.suuchi.membership.MemberAddress
 import in.ashwanthkumar.suuchi.router.ConsistentHashingRouting
-import in.ashwanthkumar.suuchi.rpc.{SuuchiPutService, SuuchiReadService, Server}
 import in.ashwanthkumar.suuchi.rpc.Server._
-import in.ashwanthkumar.suuchi.store.InMemoryStore
+import in.ashwanthkumar.suuchi.rpc.{Server, SuuchiPutService, SuuchiReadService}
 import in.ashwanthkumar.suuchi.store.rocksdb.{RocksDbConfiguration, RocksDbStore}
 import io.grpc.netty.NettyServerBuilder
-import org.apache.commons.io.FileUtils
 
 object DistributedRocksDb extends App {
   val path1 = Files.createTempDirectory("distributed-rocksdb").toFile

--- a/src/main/scala/in/ashwanthkumar/suuchi/example/ExampleApp.scala
+++ b/src/main/scala/in/ashwanthkumar/suuchi/example/ExampleApp.scala
@@ -1,6 +1,5 @@
 package in.ashwanthkumar.suuchi.example
 
-import in.ashwanthkumar.suuchi.membership.MemberAddress
 import in.ashwanthkumar.suuchi.router.ConsistentHashingRouting
 import in.ashwanthkumar.suuchi.rpc.Server.whoami
 import in.ashwanthkumar.suuchi.rpc.{Server, SuuchiPutService, SuuchiReadService}

--- a/src/main/scala/in/ashwanthkumar/suuchi/membership/Member.scala
+++ b/src/main/scala/in/ashwanthkumar/suuchi/membership/Member.scala
@@ -2,4 +2,19 @@ package in.ashwanthkumar.suuchi.membership
 
 case class Member(id: String)
 
-case class MemberAddress(host: String, port: Int)
+case class MemberAddress(host: String, port: Int) {
+  def toExternalForm = s"$host:$port"
+}
+
+object MemberAddress {
+  /**
+   * Constructs a MemberAddress from host:port string format
+   *
+   * @param hostPort  Host:Port format of a node address
+   * @return MemberAddress
+   */
+  def apply(hostPort: String): MemberAddress = {
+    val parts = hostPort.split(":")
+    MemberAddress(parts(0), parts(1).toInt)
+  }
+}

--- a/src/main/scala/in/ashwanthkumar/suuchi/membership/Membership.scala
+++ b/src/main/scala/in/ashwanthkumar/suuchi/membership/Membership.scala
@@ -2,16 +2,13 @@ package in.ashwanthkumar.suuchi.membership
 
 import java.io.File
 import java.time.Duration
-import java.util
 import java.util.function.Consumer
 
 import io.atomix.AtomixReplica
-import io.atomix.catalyst.transport
 import io.atomix.catalyst.transport.Address
 import io.atomix.catalyst.transport.netty.NettyTransport
-import io.atomix.copycat.server.storage.{StorageLevel, Storage}
-import io.atomix.group.{DistributedGroup, LocalMember, GroupMember}
-import io.atomix.variables.DistributedValue
+import io.atomix.copycat.server.storage.{Storage, StorageLevel}
+import io.atomix.group.{GroupMember, LocalMember}
 import org.slf4j.LoggerFactory
 
 import scala.collection.JavaConversions._

--- a/src/main/scala/in/ashwanthkumar/suuchi/partitioner/ConsistentHashRing.scala
+++ b/src/main/scala/in/ashwanthkumar/suuchi/partitioner/ConsistentHashRing.scala
@@ -14,7 +14,6 @@ class ConsistentHashRing(hashFn: Hash, vnodeFactor: Int = 3) {
   // duplicates
   val MAX_DUPES = 10
 
-
   def init(nodes: List[MemberAddress]) = {
     nodes.foreach(add)
     this

--- a/src/main/scala/in/ashwanthkumar/suuchi/partitioner/Partitioner.scala
+++ b/src/main/scala/in/ashwanthkumar/suuchi/partitioner/Partitioner.scala
@@ -1,9 +1,5 @@
 package in.ashwanthkumar.suuchi.partitioner
 
-import java.nio.ByteBuffer
-import java.util
-import java.util.concurrent.ConcurrentMap
-
 import in.ashwanthkumar.suuchi.membership.MemberAddress
 
 import scala.util.hashing.MurmurHash3

--- a/src/main/scala/in/ashwanthkumar/suuchi/router/HandleOrForwardRouter.scala
+++ b/src/main/scala/in/ashwanthkumar/suuchi/router/HandleOrForwardRouter.scala
@@ -28,7 +28,7 @@ class HandleOrForwardRouter(routingStrategy: RoutingStrategy, self: MemberAddres
           val eligibleNodes = routingStrategy route incomingRequest
           // Always set ELIGIBLE_NODES header to the list of nodes eligible in the current
           // operation - as defined by the RoutingStrategy
-          headers.put(Metadata.Key.of(Headers.ELIGIBLE_NODES, ListOfNodesMarshaller), eligibleNodes)
+          headers.put(Metadata.Key.of(Headers.ELIGIBLE_NODES, MemberAddressMarshaller), eligibleNodes)
 
           eligibleNodes match {
             case nodes if nodes.nonEmpty && !nodes.exists(_.equals(self)) =>

--- a/src/main/scala/in/ashwanthkumar/suuchi/router/Headers.scala
+++ b/src/main/scala/in/ashwanthkumar/suuchi/router/Headers.scala
@@ -1,0 +1,6 @@
+package in.ashwanthkumar.suuchi.router
+
+object Headers {
+  val ELIGIBLE_NODES = "eligible_nodes"
+  val REPLICATION_REQUEST = "replication_request"
+}

--- a/src/main/scala/in/ashwanthkumar/suuchi/router/Marshallers.scala
+++ b/src/main/scala/in/ashwanthkumar/suuchi/router/Marshallers.scala
@@ -1,0 +1,20 @@
+package in.ashwanthkumar.suuchi.router
+
+import in.ashwanthkumar.suuchi.membership.MemberAddress
+import io.grpc.Metadata.AsciiMarshaller
+
+/**
+ * Send a string value using AsciiMarshaller
+ */
+case object StringMarshaller extends AsciiMarshaller[String] {
+  override def toAsciiString(value: String): String = value
+  override def parseAsciiString(serialized: String): String = serialized
+}
+
+/**
+ * Converts a collection of [[MemberAddress]] to it's external form separated by `|`
+ */
+case object ListOfNodesMarshaller extends AsciiMarshaller[List[MemberAddress]] {
+  override def parseAsciiString(serialized: String): List[MemberAddress] = serialized.split('|').map(MemberAddress.apply).toList
+  override def toAsciiString(value: List[MemberAddress]): String = value.map(_.toExternalForm).mkString("|")
+}

--- a/src/main/scala/in/ashwanthkumar/suuchi/router/Marshallers.scala
+++ b/src/main/scala/in/ashwanthkumar/suuchi/router/Marshallers.scala
@@ -14,7 +14,7 @@ case object StringMarshaller extends AsciiMarshaller[String] {
 /**
  * Converts a collection of [[MemberAddress]] to it's external form separated by `|`
  */
-case object ListOfNodesMarshaller extends AsciiMarshaller[List[MemberAddress]] {
+case object MemberAddressMarshaller extends AsciiMarshaller[List[MemberAddress]] {
   override def parseAsciiString(serialized: String): List[MemberAddress] = serialized.split('|').map(MemberAddress.apply).toList
   override def toAsciiString(value: List[MemberAddress]): String = value.map(_.toExternalForm).mkString("|")
 }

--- a/src/main/scala/in/ashwanthkumar/suuchi/router/ReplicationRouter.scala
+++ b/src/main/scala/in/ashwanthkumar/suuchi/router/ReplicationRouter.scala
@@ -1,90 +1,107 @@
 package in.ashwanthkumar.suuchi.router
 
 import in.ashwanthkumar.suuchi.membership.MemberAddress
-import in.ashwanthkumar.suuchi.rpc.SuuchiRPC.PutRequest
-import io.grpc.Metadata.{AsciiMarshaller, AsciiKey}
+import io.grpc.Metadata.AsciiMarshaller
 import io.grpc.ServerCall.Listener
 import io.grpc._
 import io.grpc.netty.NettyChannelBuilder
-import io.grpc.stub.{MetadataUtils, ClientCalls}
+import io.grpc.stub.{ClientCalls, MetadataUtils}
 import org.slf4j.LoggerFactory
 
 
-case object StringMarshaller extends AsciiMarshaller[String] {
-  override def toAsciiString(value: String): String = value
-  override def parseAsciiString(serialized: String): String = serialized
-}
 /**
  * Replication Router picks up the set of nodes to which this request needs to be sent to (if not already set)
  * and forwards the request to the list of nodes in parallel and waits for all of them to complete
- *
- * @param routingStrategy
  */
-class ReplicationRouter(routingStrategy: RoutingStrategy, nrReplicas: Int, self: MemberAddress) extends ServerInterceptor {
-  val REPLICATION_REQUEST = "replication_request"
-  val REPLICATION_REQUEST_KEY = Metadata.Key.of(REPLICATION_REQUEST, StringMarshaller)
-  private val log = LoggerFactory.getLogger(getClass)
+abstract class ReplicationRouter(nrReplicas: Int, self: MemberAddress) extends ServerInterceptor {
+  me =>
+  val REPLICATION_REQUEST_KEY = Metadata.Key.of(Headers.REPLICATION_REQUEST, StringMarshaller)
+  val ELIGIBLE_NODES_KEY = Metadata.Key.of(Headers.ELIGIBLE_NODES, ListOfNodesMarshaller)
+  var forwarded = false
+
+  protected val log = LoggerFactory.getLogger(me.getClass)
 
   override def interceptCall[ReqT, RespT](serverCall: ServerCall[ReqT, RespT], headers: Metadata, next: ServerCallHandler[ReqT, RespT]): Listener[ReqT] = {
     log.trace("Intercepting " + serverCall.getMethodDescriptor.getFullMethodName + " method in " + self)
+    val replicator = this
     new Listener[ReqT] {
       val delegate = next.startCall(serverCall, headers)
-      var forwarded = false
 
       override def onReady(): Unit = delegate.onReady()
       override def onMessage(incomingRequest: ReqT): Unit = {
-        if(headers.containsKey(REPLICATION_REQUEST_KEY) && headers.get(REPLICATION_REQUEST_KEY).equals(self.toString)) {
+        log.trace("onMessage in replicator")
+        // TODO(ashwanthkumar) - Do we need the `.equals(self.toString)` check?
+        // because only forwarded message would have REPLICATION_REQUEST_KEY header anyway
+        if (headers.containsKey(REPLICATION_REQUEST_KEY) && headers.get(REPLICATION_REQUEST_KEY).equals(self.toString)) {
           log.info("Received replication request for {}, processing it", incomingRequest)
           delegate.onMessage(incomingRequest)
-        }
-        else {
-          if (routingStrategy.route.isDefinedAt(incomingRequest)) {
-            routingStrategy route incomingRequest match {
-              case nodes if nodes.size < nrReplicas =>
-                log.warn("We don't have enough nodes to satisfy the replication factor. Not processing this request")
-                serverCall.close(Status.FAILED_PRECONDITION, headers)
-              case nodes if nodes.nonEmpty =>
-                log.info("Replication nodes for {} are {}", incomingRequest, nodes)
-                log.debug("Sequentially sending out replication requests to the above set of nodes")
-                nodes.foreach { node =>
-                  forward(serverCall, headers, incomingRequest, node)
-                }
-              case _ =>
-                log.error("This should never happen. No nodes found to place replica")
-                serverCall.close(Status.INTERNAL, headers)
-            }
-          } else {
-            log.trace("Calling delegate's onMessage since router can't understand this message")
-            delegate.onMessage(incomingRequest)
-          }
+        } else if (headers.containsKey(ELIGIBLE_NODES_KEY)) {
+          // since this isn't a replication request - replicate the request to list of nodes as defined in ELIGIBLE_NODES header
+          val nodes = headers.get(ELIGIBLE_NODES_KEY)
+          log.trace("Going to replicate the request to {}", nodes)
+          replicator.replicate(nodes, serverCall, headers, incomingRequest, delegate)
+          log.trace("Replication complete for {}", incomingRequest)
+        } else {
+          log.trace("Ignoring the request since I don't know what to do")
         }
       }
 
       override def onHalfClose(): Unit = {
         // apparently default ServerCall listener seems to hold some state from OnMessage which fails
         // here and client fails with an exception message -- Half-closed without a request
-        if (forwarded) serverCall.close(Status.OK, headers) else delegate.onHalfClose()
+        if (replicator.forwarded) serverCall.close(Status.OK, headers) else delegate.onHalfClose()
       }
       override def onCancel(): Unit = delegate.onCancel()
       override def onComplete(): Unit = delegate.onComplete()
     }
   }
 
-  def forward[RespT, ReqT](serverCall: ServerCall[ReqT, RespT], headers: Metadata, incomingRequest: ReqT, node: MemberAddress): RespT = {
+  def forward[RespT, ReqT](methodDescriptor: MethodDescriptor[ReqT, RespT], headers: Metadata, incomingRequest: ReqT, destination: MemberAddress): Any = {
+    forwarded = true
     // Add HEADER to signify that this is a REPLICATION_REQUEST
-    headers.put(Metadata.Key.of(REPLICATION_REQUEST, new AsciiMarshaller[String] {override def toAsciiString(value: String): String = value
-      override def parseAsciiString(serialized: String): String = serialized
-    }), node.toString)
-
-    val nettyChannel = NettyChannelBuilder.forAddress(node.host, node.port).usePlaintext(true).build()
+    headers.put(Metadata.Key.of(Headers.REPLICATION_REQUEST, StringMarshaller), destination.toString)
+    val nettyChannel = NettyChannelBuilder.forAddress(destination.host, destination.port).usePlaintext(true).build()
 
     val clientResponse = ClientCalls.blockingUnaryCall(
       ClientInterceptors.interceptForward(nettyChannel, MetadataUtils.newAttachHeadersInterceptor(headers)),
-      serverCall.getMethodDescriptor,
+      methodDescriptor,
       CallOptions.DEFAULT,
       incomingRequest)
 
     nettyChannel.shutdown()
     clientResponse
+  }
+
+  /**
+   * Subclasses can choose to implement on how they want to replicate.
+   *
+   * See [[SequentialReplicator]] for usage.
+   */
+  def replicate[ReqT, RespT](eligibleNodes: List[MemberAddress], serverCall: ServerCall[ReqT, RespT], headers: Metadata, incomingRequest: ReqT, delegate: ServerCall.Listener[ReqT]): Unit
+}
+
+class SequentialReplicator(nrReplicas: Int, self: MemberAddress) extends ReplicationRouter(nrReplicas, self) {
+  override def replicate[ReqT, RespT](eligibleNodes: List[MemberAddress], serverCall: ServerCall[ReqT, RespT], headers: Metadata, incomingRequest: ReqT, delegate: Listener[ReqT]): Unit = {
+    eligibleNodes match {
+      case nodes if nodes.size < nrReplicas =>
+        log.warn("We don't have enough nodes to satisfy the replication factor. Not processing this request")
+        serverCall.close(Status.FAILED_PRECONDITION, headers)
+      case nodes if nodes.nonEmpty =>
+        log.info("Replication nodes for {} are {}", incomingRequest, nodes)
+        log.debug("Sequentially sending out replication requests to the above set of nodes")
+        var iamfound = false
+        eligibleNodes.foreach {
+          case node if node == self => iamfound = true
+          case destination => forward(serverCall.getMethodDescriptor, headers, incomingRequest, destination)
+        }
+        // we need to push this after the forwarding else we return to client immediately saying we're done
+        if (iamfound) {
+          delegate.onMessage(incomingRequest)
+          forwarded = false // FIXME - we had to unset this here since the actual service method is invoked only on onHalfClose()
+        }
+      case Nil =>
+        log.error("This should never happen. No nodes found to place replica")
+        serverCall.close(Status.INTERNAL, headers)
+    }
   }
 }

--- a/src/main/scala/in/ashwanthkumar/suuchi/router/ReplicationRouter.scala
+++ b/src/main/scala/in/ashwanthkumar/suuchi/router/ReplicationRouter.scala
@@ -13,10 +13,9 @@ import org.slf4j.LoggerFactory
  * Replication Router picks up the set of nodes to which this request needs to be sent to (if not already set)
  * and forwards the request to the list of nodes in parallel and waits for all of them to complete
  */
-abstract class ReplicationRouter(nrReplicas: Int, self: MemberAddress) extends ServerInterceptor {
-  me =>
+abstract class ReplicationRouter(nrReplicas: Int, self: MemberAddress) extends ServerInterceptor { me =>
   val REPLICATION_REQUEST_KEY = Metadata.Key.of(Headers.REPLICATION_REQUEST, StringMarshaller)
-  val ELIGIBLE_NODES_KEY = Metadata.Key.of(Headers.ELIGIBLE_NODES, ListOfNodesMarshaller)
+  val ELIGIBLE_NODES_KEY = Metadata.Key.of(Headers.ELIGIBLE_NODES, MemberAddressMarshaller)
   var forwarded = false
 
   protected val log = LoggerFactory.getLogger(me.getClass)

--- a/src/test/scala/in/ashwanthkumar/suuchi/membership/MembershipIntegrationSpec.scala
+++ b/src/test/scala/in/ashwanthkumar/suuchi/membership/MembershipIntegrationSpec.scala
@@ -3,8 +3,8 @@ package in.ashwanthkumar.suuchi.membership
 import java.nio.file.Files
 
 import org.apache.commons.io.FileUtils
+import org.scalatest.Matchers.{convertToAnyShouldWrapper, have}
 import org.scalatest.{BeforeAndAfter, FlatSpec}
-import org.scalatest.Matchers.{convertToAnyShouldWrapper, be, have, size}
 
 class MembershipIntegrationSpec extends FlatSpec with BeforeAndAfter {
 

--- a/src/test/scala/in/ashwanthkumar/suuchi/router/HandleOrForwardRouterSpec.scala
+++ b/src/test/scala/in/ashwanthkumar/suuchi/router/HandleOrForwardRouterSpec.scala
@@ -14,7 +14,7 @@ class NeverRoute extends RoutingStrategy {
   override def route[ReqT]: PartialFunction[ReqT, List[MemberAddress]] = PartialFunction.empty
 }
 
-class RouterSpec extends FlatSpec {
+class HandleOrForwardRouterSpec extends FlatSpec {
   "Router" should "not forward messages if routing strategy doesn't say so" in {
     val router = new HandleOrForwardRouter(new NeverRoute(), MemberAddress("host2", 1))
     verifyInteractions(router, isForwarded = false)
@@ -28,7 +28,7 @@ class RouterSpec extends FlatSpec {
   it should "forward message when router says so" in {
     val router = new HandleOrForwardRouter(new AlwaysRouteTo(MemberAddress("host1", 1)), MemberAddress("host2", 1)) {
       // mocking the actual forward implementation
-      override def forward[RespT, ReqT](serverCall: ServerCall[ReqT, RespT], incomingRequest: ReqT, node: MemberAddress): RespT = 1.asInstanceOf[RespT]
+      override def forward[RespT, ReqT](serverCall: ServerCall[ReqT, RespT], headers: Metadata, incomingRequest: ReqT, node: MemberAddress, allNodes: List[MemberAddress]): RespT = 1.asInstanceOf[RespT]
     }
     verifyInteractions(router, isForwarded = true)
   }

--- a/src/test/scala/in/ashwanthkumar/suuchi/router/HandleOrForwardRouterSpec.scala
+++ b/src/test/scala/in/ashwanthkumar/suuchi/router/HandleOrForwardRouterSpec.scala
@@ -2,7 +2,7 @@ package in.ashwanthkumar.suuchi.router
 
 import in.ashwanthkumar.suuchi.membership.MemberAddress
 import io.grpc.ServerCall.Listener
-import io.grpc.{Metadata, MethodDescriptor, ServerCall, ServerCallHandler}
+import io.grpc._
 import org.mockito.Matchers._
 import org.mockito.Mockito._
 import org.scalatest.FlatSpec
@@ -14,15 +14,29 @@ class NeverRoute extends RoutingStrategy {
   override def route[ReqT]: PartialFunction[ReqT, List[MemberAddress]] = PartialFunction.empty
 }
 
+class NoAliveNodes extends RoutingStrategy {
+  /**
+   * @inheritdoc
+   */
+  override def route[ReqT]: PartialFunction[ReqT, List[MemberAddress]] = {
+    case _ => Nil
+  }
+}
+
 class HandleOrForwardRouterSpec extends FlatSpec {
   "Router" should "not forward messages if routing strategy doesn't say so" in {
     val router = new HandleOrForwardRouter(new NeverRoute(), MemberAddress("host2", 1))
-    verifyInteractions(router, isForwarded = false)
+    verifyInteractions(router, isForwarded = false, isHandledLocally = true)
+  }
+
+  it should "not forward messages if no nodes are alive" in {
+    val router = new HandleOrForwardRouter(new NoAliveNodes(), MemberAddress("host2", 1))
+    verifyInteractions(router, isForwarded = false, isHandledLocally = false)
   }
 
   it should "not forward message when router emits node to self" in {
     val router = new HandleOrForwardRouter(new AlwaysRouteTo(MemberAddress("host2", 1)), MemberAddress("host2", 1))
-    verifyInteractions(router, isForwarded = false)
+    verifyInteractions(router, isForwarded = false, isHandledLocally = true)
   }
 
   it should "forward message when router says so" in {
@@ -30,10 +44,10 @@ class HandleOrForwardRouterSpec extends FlatSpec {
       // mocking the actual forward implementation
       override def forward[RespT, ReqT](serverCall: ServerCall[ReqT, RespT], headers: Metadata, incomingRequest: ReqT, node: MemberAddress, allNodes: List[MemberAddress]): RespT = 1.asInstanceOf[RespT]
     }
-    verifyInteractions(router, isForwarded = true)
+    verifyInteractions(router, isForwarded = true, isHandledLocally = false)
   }
 
-  def verifyInteractions(router: HandleOrForwardRouter, isForwarded: Boolean): Unit = {
+  def verifyInteractions(router: HandleOrForwardRouter, isForwarded: Boolean, isHandledLocally: Boolean): Unit = {
     val serverCall = mock(classOf[ServerCall[Int, Int]])
     val serverMethodDesc = mock(classOf[MethodDescriptor[Int, Int]])
     when(serverCall.getMethodDescriptor).thenReturn(serverMethodDesc)
@@ -57,9 +71,13 @@ class HandleOrForwardRouterSpec extends FlatSpec {
 
       verify(serverCall, times(1)).sendHeaders(any(classOf[Metadata]))
       verify(serverCall, times(1)).sendMessage(1)
-    } else {
+    } else if(isHandledLocally) {
       verify(delegate, times(1)).onMessage(1)
       verify(delegate, times(1)).onHalfClose()
+    } else {
+      verify(serverCall, times(0)).sendHeaders(any(classOf[Metadata]))
+      verify(serverCall, times(0)).sendMessage(1)
+      verify(serverCall, times(1)).close(any(classOf[Status]), any(classOf[Metadata]))
     }
     verify(delegate, times(1)).onComplete()
     verify(delegate, times(1)).onCancel()

--- a/src/test/scala/in/ashwanthkumar/suuchi/router/HandleOrForwardRouterSpec.scala
+++ b/src/test/scala/in/ashwanthkumar/suuchi/router/HandleOrForwardRouterSpec.scala
@@ -42,7 +42,7 @@ class HandleOrForwardRouterSpec extends FlatSpec {
   it should "forward message when router says so" in {
     val router = new HandleOrForwardRouter(new AlwaysRouteTo(MemberAddress("host1", 1)), MemberAddress("host2", 1)) {
       // mocking the actual forward implementation
-      override def forward[RespT, ReqT](serverCall: ServerCall[ReqT, RespT], headers: Metadata, incomingRequest: ReqT, node: MemberAddress, allNodes: List[MemberAddress]): RespT = 1.asInstanceOf[RespT]
+      override def forward[RespT, ReqT](method: MethodDescriptor[ReqT, RespT], headers: Metadata, incomingRequest: ReqT, destination: MemberAddress): RespT = 1.asInstanceOf[RespT]
     }
     verifyInteractions(router, isForwarded = true, isHandledLocally = false)
   }

--- a/src/test/scala/in/ashwanthkumar/suuchi/router/ListOfNodesMarshallerSpec.scala
+++ b/src/test/scala/in/ashwanthkumar/suuchi/router/ListOfNodesMarshallerSpec.scala
@@ -2,7 +2,7 @@ package in.ashwanthkumar.suuchi.router
 
 import in.ashwanthkumar.suuchi.membership.MemberAddress
 import org.scalatest.FlatSpec
-import org.scalatest.Matchers.{convertToAnyShouldWrapper, be, have, contain}
+import org.scalatest.Matchers.{be, contain, convertToAnyShouldWrapper, have}
 
 class ListOfNodesMarshallerSpec extends FlatSpec {
   "ListOfNodesMarshaller" should "convert list of members to ascii string" in {

--- a/src/test/scala/in/ashwanthkumar/suuchi/router/ListOfNodesMarshallerSpec.scala
+++ b/src/test/scala/in/ashwanthkumar/suuchi/router/ListOfNodesMarshallerSpec.scala
@@ -1,0 +1,26 @@
+package in.ashwanthkumar.suuchi.router
+
+import in.ashwanthkumar.suuchi.membership.MemberAddress
+import org.scalatest.FlatSpec
+import org.scalatest.Matchers.{convertToAnyShouldWrapper, be, have, contain}
+
+class ListOfNodesMarshallerSpec extends FlatSpec {
+  "ListOfNodesMarshaller" should "convert list of members to ascii string" in {
+    val members = List(
+      MemberAddress("localhost", 5051),
+      MemberAddress("localhost", 5052),
+      MemberAddress("localhost", 5053)
+    )
+
+    MemberAddressMarshaller.toAsciiString(members) should be("localhost:5051|localhost:5052|localhost:5053")
+  }
+
+  it should "convert the ascii string to actual node objects" in {
+    val members = MemberAddressMarshaller.parseAsciiString("localhost:5051|localhost:5052|localhost:5053")
+    members should have size 3
+
+    members should contain(MemberAddress("localhost", 5051))
+    members should contain(MemberAddress("localhost", 5052))
+    members should contain(MemberAddress("localhost", 5053))
+  }
+}

--- a/src/test/scala/in/ashwanthkumar/suuchi/router/ReplicationRouterSpec.scala
+++ b/src/test/scala/in/ashwanthkumar/suuchi/router/ReplicationRouterSpec.scala
@@ -1,0 +1,99 @@
+package in.ashwanthkumar.suuchi.router
+
+import in.ashwanthkumar.suuchi.membership.MemberAddress
+import io.grpc
+import io.grpc.ServerCall.Listener
+import io.grpc.{ServerCallHandler, MethodDescriptor, Metadata, ServerCall}
+import org.mockito.Matchers._
+import org.scalatest.FlatSpec
+import org.scalatest.Matchers.{convertToAnyShouldWrapper, be}
+import org.mockito.Mockito._
+import org.mockito.Matchers
+
+class NoReplicator(nrOfReplicas: Int, self: MemberAddress) extends ReplicationRouter(nrOfReplicas, self) {
+  override def replicate[ReqT, RespT](eligibleNodes: scala.List[MemberAddress], serverCall: ServerCall[ReqT, RespT], headers: Metadata, incomingRequest: ReqT, delegate: ServerCall.Listener[ReqT]): Unit = {}
+}
+
+class MockReplicator(nrOfReplicas: Int, self: MemberAddress, mock: ReplicationRouter) extends ReplicationRouter(nrOfReplicas, self) {
+  /**
+   * @inheritdoc
+   */
+  override def replicate[ReqT, RespT](eligibleNodes: scala.List[_root_.in.ashwanthkumar.suuchi.membership.MemberAddress], serverCall: _root_.io.grpc.ServerCall[ReqT, RespT], headers: _root_.io.grpc.Metadata, incomingRequest: ReqT, delegate: _root_.io.grpc.ServerCall.Listener[ReqT]): Unit = {
+    mock.replicate(eligibleNodes, serverCall, headers, incomingRequest, delegate)
+  }
+}
+
+class ReplicationRouterSpec extends FlatSpec {
+  "ReplicationRouter" should "delete the message to the local node if it's a REPLICATION_REQUEST" in {
+    val whoami = MemberAddress("host1", 1)
+    val replicator = new NoReplicator(1, whoami)
+
+    setupAndVerify { (serverCall: ServerCall[Int, Int], delegate: ServerCall.Listener[Int], next: ServerCallHandler[Int, Int]) =>
+      when(next.startCall(any(classOf[ServerCall[Int, Int]]), any(classOf[Metadata]))).thenReturn(delegate)
+      val headers = new Metadata()
+      headers.put(ReplicationRouter.REPLICATION_REQUEST_KEY, whoami.toString)
+
+      val listener = replicator.interceptCall(serverCall, headers, next)
+      listener.onReady()
+      listener.onMessage(1)
+      listener.onHalfClose()
+      listener.onComplete()
+      listener.onCancel()
+
+      verify(delegate, times(1)).onReady()
+      verify(delegate, times(1)).onMessage(1)
+    }
+  }
+
+  it should "not do anything if no required headers are present" in {
+    val whoami = MemberAddress("host1", 1)
+    val replicator = new NoReplicator(1, whoami)
+
+    setupAndVerify { (serverCall: ServerCall[Int, Int], delegate: ServerCall.Listener[Int], next: ServerCallHandler[Int, Int]) =>
+      val headers = new Metadata()
+      val listener = replicator.interceptCall(serverCall, headers, next)
+      listener.onReady()
+      listener.onMessage(1)
+      listener.onHalfClose()
+      listener.onComplete()
+      listener.onCancel()
+
+      verify(delegate, times(1)).onReady()
+      verify(delegate, times(0)).onMessage(1)
+    }
+  }
+
+  it should "replicate the request as per replication strategy" in {
+    val whoami = MemberAddress("host1", 1)
+    val mockReplicator = mock(classOf[ReplicationRouter])
+    val replicator = new MockReplicator(1, whoami, mockReplicator)
+
+    setupAndVerify { (serverCall: ServerCall[Int, Int], delegate: ServerCall.Listener[Int], next: ServerCallHandler[Int, Int]) =>
+      val headers = new Metadata()
+      headers.put(ReplicationRouter.ELIGIBLE_NODES_KEY, List(whoami))
+      val listener = replicator.interceptCall(serverCall, headers, next)
+      listener.onReady()
+      listener.onMessage(1)
+      listener.onHalfClose()
+      listener.onComplete()
+      listener.onCancel()
+
+      verify(delegate, times(1)).onReady()
+      verify(delegate, times(0)).onMessage(1)
+      verify(mockReplicator, times(1)).replicate[Int, Int](any(classOf[List[MemberAddress]]), any(classOf[ServerCall[Int, Int]]), any(classOf[Metadata]), anyInt(), any(classOf[ServerCall.Listener[Int]]))
+    }
+  }
+
+  def setupAndVerify(verify: (ServerCall[Int, Int], ServerCall.Listener[Int], ServerCallHandler[Int, Int]) => Unit): Unit = {
+    val serverCall = mock(classOf[ServerCall[Int, Int]])
+    val serverMethodDesc = mock(classOf[MethodDescriptor[Int, Int]])
+    when(serverCall.getMethodDescriptor).thenReturn(serverMethodDesc)
+    when(serverMethodDesc.getFullMethodName).thenReturn("TestService/Test")
+
+    val delegate = mock(classOf[Listener[Int]])
+    val next = mock(classOf[ServerCallHandler[Int, Int]])
+    when(next.startCall(any(classOf[ServerCall[Int, Int]]), any(classOf[Metadata]))).thenReturn(delegate)
+
+    verify(serverCall, delegate, next)
+  }
+}

--- a/src/test/scala/in/ashwanthkumar/suuchi/router/ReplicationRouterSpec.scala
+++ b/src/test/scala/in/ashwanthkumar/suuchi/router/ReplicationRouterSpec.scala
@@ -1,14 +1,11 @@
 package in.ashwanthkumar.suuchi.router
 
 import in.ashwanthkumar.suuchi.membership.MemberAddress
-import io.grpc
 import io.grpc.ServerCall.Listener
-import io.grpc.{ServerCallHandler, MethodDescriptor, Metadata, ServerCall}
+import io.grpc.{Metadata, MethodDescriptor, ServerCall, ServerCallHandler}
 import org.mockito.Matchers._
-import org.scalatest.FlatSpec
-import org.scalatest.Matchers.{convertToAnyShouldWrapper, be}
 import org.mockito.Mockito._
-import org.mockito.Matchers
+import org.scalatest.FlatSpec
 
 class NoReplicator(nrOfReplicas: Int, self: MemberAddress) extends ReplicationRouter(nrOfReplicas, self) {
   override def replicate[ReqT, RespT](eligibleNodes: scala.List[MemberAddress], serverCall: ServerCall[ReqT, RespT], headers: Metadata, incomingRequest: ReqT, delegate: ServerCall.Listener[ReqT]): Unit = {}

--- a/src/test/scala/in/ashwanthkumar/suuchi/router/ReplicationRouterSpec.scala
+++ b/src/test/scala/in/ashwanthkumar/suuchi/router/ReplicationRouterSpec.scala
@@ -21,7 +21,7 @@ class MockReplicator(nrOfReplicas: Int, self: MemberAddress, mock: ReplicationRo
 }
 
 class ReplicationRouterSpec extends FlatSpec {
-  "ReplicationRouter" should "delete the message to the local node if it's a REPLICATION_REQUEST" in {
+  "ReplicationRouter" should "delegate the message to the local node if it's a REPLICATION_REQUEST" in {
     val whoami = MemberAddress("host1", 1)
     val replicator = new NoReplicator(1, whoami)
 

--- a/src/test/scala/in/ashwanthkumar/suuchi/router/SequentialReplicatorSpec.scala
+++ b/src/test/scala/in/ashwanthkumar/suuchi/router/SequentialReplicatorSpec.scala
@@ -1,12 +1,11 @@
 package in.ashwanthkumar.suuchi.router
 
 import in.ashwanthkumar.suuchi.membership.MemberAddress
-import io.grpc.{MethodDescriptor, Status, Metadata, ServerCall}
-import io.grpc.stub.ServerCalls
-import org.scalatest.FlatSpec
-import org.mockito.Mockito._
-import org.mockito.Matchers._
+import io.grpc.{Metadata, MethodDescriptor, ServerCall, Status}
 import org.mockito.Matchers
+import org.mockito.Matchers._
+import org.mockito.Mockito._
+import org.scalatest.FlatSpec
 
 class TestSequentialReplicator(nrReplicas: Int, self: MemberAddress) extends SequentialReplicator(nrReplicas, self) {
   override def forward[RespT, ReqT](methodDescriptor: MethodDescriptor[ReqT, RespT], headers: Metadata, incomingRequest: ReqT, destination: MemberAddress): Any = {}

--- a/src/test/scala/in/ashwanthkumar/suuchi/router/SequentialReplicatorSpec.scala
+++ b/src/test/scala/in/ashwanthkumar/suuchi/router/SequentialReplicatorSpec.scala
@@ -1,0 +1,70 @@
+package in.ashwanthkumar.suuchi.router
+
+import in.ashwanthkumar.suuchi.membership.MemberAddress
+import io.grpc.{MethodDescriptor, Status, Metadata, ServerCall}
+import io.grpc.stub.ServerCalls
+import org.scalatest.FlatSpec
+import org.mockito.Mockito._
+import org.mockito.Matchers._
+import org.mockito.Matchers
+
+class TestSequentialReplicator(nrReplicas: Int, self: MemberAddress) extends SequentialReplicator(nrReplicas, self) {
+  override def forward[RespT, ReqT](methodDescriptor: MethodDescriptor[ReqT, RespT], headers: Metadata, incomingRequest: ReqT, destination: MemberAddress): Any = {}
+}
+
+class MockSequentialReplicator(nrReplicas: Int, self: MemberAddress, mock: SequentialReplicator) extends SequentialReplicator(nrReplicas, self) {
+  override def forward[RespT, ReqT](methodDescriptor: MethodDescriptor[ReqT, RespT], headers: Metadata, incomingRequest: ReqT, destination: MemberAddress): Any = {
+    mock.forward(methodDescriptor, headers, incomingRequest, destination)
+  }
+}
+
+class SequentialReplicatorSpec extends FlatSpec {
+  "SequentialReplicator" should "fail if number of nodes is < expected replicas" in {
+    val replicator = new TestSequentialReplicator(3, MemberAddress("host1", 1))
+    val serverCall = mock(classOf[ServerCall[Int, Int]])
+    val delegate = mock(classOf[ServerCall.Listener[Int]])
+    val headers = new Metadata()
+    replicator.replicate[Int, Int](List(MemberAddress("host1", 1)), serverCall, headers, 1, delegate)
+
+    verify(serverCall, times(1)).close(Status.FAILED_PRECONDITION, headers)
+  }
+
+  it should "fail if no nodes were sent to replicate" in {
+    val replicator = new TestSequentialReplicator(0, MemberAddress("host1", 1))
+    val serverCall = mock(classOf[ServerCall[Int, Int]])
+    val delegate = mock(classOf[ServerCall.Listener[Int]])
+    val headers = new Metadata()
+    replicator.replicate[Int, Int](Nil, serverCall, headers, 1, delegate)
+
+    verify(serverCall, times(1)).close(Status.INTERNAL, headers)
+  }
+
+  it should "sequentially send forwards to the replicas" in {
+    val mockReplicator = mock(classOf[SequentialReplicator])
+    val replicator = new MockSequentialReplicator(2, MemberAddress("host1", 1), mockReplicator)
+    val serverCall = mock(classOf[ServerCall[Int, Int]])
+    val delegate = mock(classOf[ServerCall.Listener[Int]])
+    val headers = new Metadata()
+    val destination1 = MemberAddress("host2", 2)
+    val destination2 = MemberAddress("host3", 3)
+    replicator.replicate[Int, Int](List(destination1, destination2), serverCall, headers, 1, delegate)
+
+    verify(mockReplicator, times(1)).forward(any(classOf[MethodDescriptor[Int, Int]]), any(classOf[Metadata]), anyInt(), Matchers.eq(destination1))
+    verify(mockReplicator, times(1)).forward(any(classOf[MethodDescriptor[Int, Int]]), any(classOf[Metadata]), anyInt(), Matchers.eq(destination2))
+  }
+
+  it should "call delegate.OnMesssage if one of the nodes to replica is self" in {
+    val mockReplicator = mock(classOf[SequentialReplicator])
+    val replicator = new MockSequentialReplicator(2, MemberAddress("host1", 1), mockReplicator)
+    val serverCall = mock(classOf[ServerCall[Int, Int]])
+    val delegate = mock(classOf[ServerCall.Listener[Int]])
+    val headers = new Metadata()
+    val destination1 = MemberAddress("host1", 1)
+    val destination2 = MemberAddress("host2", 2)
+    replicator.replicate[Int, Int](List(destination1, destination2), serverCall, headers, 1, delegate)
+
+    verify(mockReplicator, times(0)).forward(any(classOf[MethodDescriptor[Int, Int]]), any(classOf[Metadata]), anyInt(), Matchers.eq(destination1))
+    verify(mockReplicator, times(1)).forward(any(classOf[MethodDescriptor[Int, Int]]), any(classOf[Metadata]), anyInt(), Matchers.eq(destination2))
+    verify(delegate, times(1)).onMessage(Matchers.eq(1))
+  }
+}

--- a/src/test/scala/in/ashwanthkumar/suuchi/router/StringMarshallerSpec.scala
+++ b/src/test/scala/in/ashwanthkumar/suuchi/router/StringMarshallerSpec.scala
@@ -1,0 +1,15 @@
+package in.ashwanthkumar.suuchi.router
+
+import in.ashwanthkumar.suuchi.membership.MemberAddress
+import org.scalatest.FlatSpec
+import org.scalatest.Matchers.{be, contain, convertToAnyShouldWrapper, have}
+
+class StringMarshallerSpec extends FlatSpec {
+   "StringMarshaller" should "return the string as is when serialised" in {
+     StringMarshaller.toAsciiString("suuchi") should be("suuchi")
+   }
+
+   it should "return the string as is when de-serialised" in {
+     StringMarshaller.parseAsciiString("suuchi") should be("suuchi")
+   }
+ }

--- a/src/test/scala/in/ashwanthkumar/suuchi/router/StringMarshallerSpec.scala
+++ b/src/test/scala/in/ashwanthkumar/suuchi/router/StringMarshallerSpec.scala
@@ -1,8 +1,7 @@
 package in.ashwanthkumar.suuchi.router
 
-import in.ashwanthkumar.suuchi.membership.MemberAddress
 import org.scalatest.FlatSpec
-import org.scalatest.Matchers.{be, contain, convertToAnyShouldWrapper, have}
+import org.scalatest.Matchers.{be, convertToAnyShouldWrapper}
 
 class StringMarshallerSpec extends FlatSpec {
    "StringMarshaller" should "return the string as is when serialised" in {

--- a/src/test/scala/in/ashwanthkumar/suuchi/store/InMemoryStoreTest.scala
+++ b/src/test/scala/in/ashwanthkumar/suuchi/store/InMemoryStoreTest.scala
@@ -1,6 +1,5 @@
 package in.ashwanthkumar.suuchi.store
 
-import com.google.protobuf.ByteString
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers.{be, convertToAnyShouldWrapper}
 

--- a/src/test/scala/in/ashwanthkumar/suuchi/store/rocksdb/RocksDbStoreSpec.scala
+++ b/src/test/scala/in/ashwanthkumar/suuchi/store/rocksdb/RocksDbStoreSpec.scala
@@ -3,8 +3,8 @@ package in.ashwanthkumar.suuchi.store.rocksdb
 import java.io.File
 
 import org.apache.commons.io.FileUtils
-import org.scalatest.{BeforeAndAfter, FlatSpec}
 import org.scalatest.Matchers._
+import org.scalatest.{BeforeAndAfter, FlatSpec}
 
 class RocksDbStoreSpec extends FlatSpec with BeforeAndAfter {
   val ROCKSDB_TEST_LOCATION = "/tmp/suuchi-rocks-test"


### PR DESCRIPTION
New Workflow for replication

```
                                Client

                                  ||
                                  ||
                                  ||
                                  \/

                                Request

                                  ||
                                  ||
                                  ||
                                  \/

                            HandleOrForward

                               /\    ||
[Header:REPLICATION_REQUEST]   ||    ||  Header: ELIGIBLE_NODES=[]
 (times: nrOfReplica)          ||    ||
                               ||    \/

                            ReplicationRouter
```

HandleOrForward Interceptor always sets a header called "ELIGIBLE_NODES" which contains list of all nodes that're eligible to participate in the current operation as defined by RoutingStrategy.

SequentialReplicator would know to replicate the incomingMessage based on ELIGIBLE_NODES, if REPLICATION_REQUEST header is not set. Now while replicating the message it would add REPLICATION_REQUEST header to those messages so ReplicationRouter on the other node (or process) will not forward the message instead just delegate it to the local handler.

As part of this change we've also made ReplicationRouter an abstract class and provided an implementation called SequentialReplicator which does Sequential replication to all the ELIGIBLE_NODES.
