### PR TITLE
Refactored replication router to support parallel writes

### DIFF
--- a/src/test/scala/in/ashwanthkumar/suuchi/router/ParallelReplicatorSpec.scala
+++ b/src/test/scala/in/ashwanthkumar/suuchi/router/ParallelReplicatorSpec.scala
@@ -1,0 +1,43 @@
+package in.ashwanthkumar.suuchi.router
+
+import java.util.concurrent.Executor
+
+import com.google.common.util.concurrent.{Futures, ListenableFuture}
+import in.ashwanthkumar.suuchi.membership.MemberAddress
+import io.grpc.{MethodDescriptor, Metadata, ServerCall}
+import org.mockito.Matchers
+import org.mockito.Matchers._
+import org.mockito.Mockito._
+import org.scalatest.{BeforeAndAfter, FlatSpec}
+
+class MockParallelReplicator(nrReplicas: Int, self: MemberAddress, mock: ParallelReplicator) extends ParallelReplicator(nrReplicas, self) {
+  override def forwardAsync[RespT, ReqT](methodDescriptor: MethodDescriptor[ReqT, RespT], headers: Metadata,
+                                         incomingRequest: ReqT, destination: MemberAddress)
+                                        (implicit executor: Executor) : ListenableFuture[RespT] = {
+    mock.forwardAsync(methodDescriptor, headers, incomingRequest, destination)
+  }
+}
+
+class ParallelReplicatorSpec extends FlatSpec with BeforeAndAfter {
+  "ParallelReplicator" should "forward requests to target nodes in parallel" in {
+    implicit val mockExecutor = mock(classOf[Executor])
+    val mockReplicator = mock(classOf[ParallelReplicator])
+    val replicator = new MockParallelReplicator(2, MemberAddress("host1", 1), mockReplicator)
+    val serverCall = mock(classOf[ServerCall[Int, Int]])
+    val delegate = mock(classOf[ServerCall.Listener[Int]])
+    val headers = new Metadata()
+    val destination1 = MemberAddress("host2", 2)
+    val destination2 = MemberAddress("host3", 3)
+
+    when(mockReplicator.forwardAsync(any(classOf[MethodDescriptor[Int, Int]]), any(classOf[Metadata]), anyInt(), Matchers.eq(destination1))(any(classOf[Executor])))
+      .thenReturn(Futures.immediateFuture(2))
+    when(mockReplicator.forwardAsync(any(classOf[MethodDescriptor[Int, Int]]), any(classOf[Metadata]), anyInt(), Matchers.eq(destination2))(any(classOf[Executor])))
+      .thenReturn(Futures.immediateFuture(3))
+
+    replicator.replicate[Int, Int](List(destination1, destination2), serverCall, headers, 1, delegate)
+
+    verify(mockReplicator, times(1)).forwardAsync(any(classOf[MethodDescriptor[Int, Int]]), any(classOf[Metadata]), anyInt(), Matchers.eq(destination1))(any(classOf[Executor]))
+    verify(mockReplicator, times(1)).forwardAsync(any(classOf[MethodDescriptor[Int, Int]]), any(classOf[Metadata]), anyInt(), Matchers.eq(destination2))(any(classOf[Executor]))
+
+  }
+}

--- a/src/test/scala/in/ashwanthkumar/suuchi/router/ReplicationRouterSpec.scala
+++ b/src/test/scala/in/ashwanthkumar/suuchi/router/ReplicationRouterSpec.scala
@@ -9,6 +9,7 @@ import org.scalatest.FlatSpec
 
 class NoReplicator(nrOfReplicas: Int, self: MemberAddress) extends ReplicationRouter(nrOfReplicas, self) {
   override def replicate[ReqT, RespT](eligibleNodes: scala.List[MemberAddress], serverCall: ServerCall[ReqT, RespT], headers: Metadata, incomingRequest: ReqT, delegate: ServerCall.Listener[ReqT]): Unit = {}
+  override def doReplication[ReqT, RespT](eligibleNodes: scala.List[_root_.in.ashwanthkumar.suuchi.membership.MemberAddress], serverCall: _root_.io.grpc.ServerCall[ReqT, RespT], headers: _root_.io.grpc.Metadata, incomingRequest: ReqT, delegate: _root_.io.grpc.ServerCall.Listener[ReqT]): Unit = ???
 }
 
 class MockReplicator(nrOfReplicas: Int, self: MemberAddress, mock: ReplicationRouter) extends ReplicationRouter(nrOfReplicas, self) {
@@ -18,6 +19,7 @@ class MockReplicator(nrOfReplicas: Int, self: MemberAddress, mock: ReplicationRo
   override def replicate[ReqT, RespT](eligibleNodes: scala.List[_root_.in.ashwanthkumar.suuchi.membership.MemberAddress], serverCall: _root_.io.grpc.ServerCall[ReqT, RespT], headers: _root_.io.grpc.Metadata, incomingRequest: ReqT, delegate: _root_.io.grpc.ServerCall.Listener[ReqT]): Unit = {
     mock.replicate(eligibleNodes, serverCall, headers, incomingRequest, delegate)
   }
+  override def doReplication[ReqT, RespT](eligibleNodes: scala.List[_root_.in.ashwanthkumar.suuchi.membership.MemberAddress], serverCall: _root_.io.grpc.ServerCall[ReqT, RespT], headers: _root_.io.grpc.Metadata, incomingRequest: ReqT, delegate: _root_.io.grpc.ServerCall.Listener[ReqT]): Unit = ???
 }
 
 class ReplicationRouterSpec extends FlatSpec {

--- a/src/test/scala/in/ashwanthkumar/suuchi/router/RoutingStrategySpec.scala
+++ b/src/test/scala/in/ashwanthkumar/suuchi/router/RoutingStrategySpec.scala
@@ -1,0 +1,17 @@
+package in.ashwanthkumar.suuchi.router
+
+import com.google.protobuf.ByteString
+import in.ashwanthkumar.suuchi.membership.MemberAddress
+import org.scalatest.FlatSpec
+import org.scalatest.Matchers._
+
+case class IntReq(i: Int) {
+  def getKey: ByteString = ByteString.copyFrom(i.toString.getBytes)
+}
+class RoutingStrategySpec extends FlatSpec {
+  "ConsistentHashingRoutingStrategy" should "route incoming requests WithKey to appropriate nodes" in {
+    val routingStrategy = ConsistentHashingRouting(2, List(MemberAddress("host1:1"),MemberAddress("host2:2"),MemberAddress("host3:3")):_*)
+    routingStrategy.route(IntReq(100)).size should be(2)
+    routingStrategy.route(IntReq(100)).distinct.size should be(2)
+  }
+}


### PR DESCRIPTION
@ashwanthkumar Implemented parallel replication. As part of this, refactored some portions of existing replicator parent class to do error handling and pushed out "actual" replication logic alone to be implemented.
