### PR TITLE
Adding first-class support for versioned store

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,10 @@
                             <compileOrder>Mixed</compileOrder>
                             <addScalacArgs>-feature</addScalacArgs>
                             <scalaVersion>${scala.version}</scalaVersion>
-                            <javacArgs>-source 1.8</javacArgs>
+                            <javacArgs>
+                                <javacArg>-source</javacArg>
+                                <javacArg>1.8</javacArg>
+                            </javacArgs>
                         </configuration>
                     </execution>
                     <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,7 @@
                             <compileOrder>Mixed</compileOrder>
                             <addScalacArgs>-feature</addScalacArgs>
                             <scalaVersion>${scala.version}</scalaVersion>
+                            <javacArgs>-source 1.8</javacArgs>
                         </configuration>
                     </execution>
                     <execution>

--- a/suuchi-core/src/main/scala/in/ashwanthkumar/suuchi/store/InMemoryStore.scala
+++ b/suuchi-core/src/main/scala/in/ashwanthkumar/suuchi/store/InMemoryStore.scala
@@ -20,4 +20,10 @@ class InMemoryStore extends Store {
     log.trace(s"GetResult for key=${new String(key)}, value=${value.map(b => new String(b))}")
     value
   }
+
+  override def remove(key: Array[Byte]): Boolean = {
+    log.trace(s"Remove for key=${new String(key)}")
+    store.remove(ByteBuffer.wrap(key))
+    true
+  }
 }

--- a/suuchi-core/src/main/scala/in/ashwanthkumar/suuchi/store/PrimitivesSerDeUtils.scala
+++ b/suuchi-core/src/main/scala/in/ashwanthkumar/suuchi/store/PrimitivesSerDeUtils.scala
@@ -8,6 +8,6 @@ object PrimitivesSerDeUtils {
   * */
   def longToBytes(instance: Long) = ByteBuffer.allocate(8).putLong(instance).array()
   def intToBytes(instance: Int) = ByteBuffer.allocate(4).putInt(instance).array()
-  def bytesToInt(bytes: Array[Byte]) = ByteBuffer.wrap(bytes).getLong
+  def bytesToInt(bytes: Array[Byte]) = ByteBuffer.wrap(bytes).getInt
   def bytesToLong(bytes: Array[Byte]) = ByteBuffer.wrap(bytes).getLong
 }

--- a/suuchi-core/src/main/scala/in/ashwanthkumar/suuchi/store/PrimitivesSerDeUtils.scala
+++ b/suuchi-core/src/main/scala/in/ashwanthkumar/suuchi/store/PrimitivesSerDeUtils.scala
@@ -1,0 +1,13 @@
+package in.ashwanthkumar.suuchi.store
+
+import java.nio.ByteBuffer
+
+object PrimitivesSerDeUtils {
+  /*
+  * FIXME: Not the most effective way to perform serde primitives.
+  * */
+  def longToBytes(instance: Long) = ByteBuffer.allocate(8).putLong(instance).array()
+  def intToBytes(instance: Int) = ByteBuffer.allocate(4).putInt(instance).array()
+  def bytesToInt(bytes: Array[Byte]) = ByteBuffer.wrap(bytes).getLong
+  def bytesToLong(bytes: Array[Byte]) = ByteBuffer.wrap(bytes).getLong
+}

--- a/suuchi-core/src/main/scala/in/ashwanthkumar/suuchi/store/Store.scala
+++ b/suuchi-core/src/main/scala/in/ashwanthkumar/suuchi/store/Store.scala
@@ -6,10 +6,7 @@ trait ReadStore {
 
 trait WriteStore {
   def put(key: Array[Byte], value: Array[Byte]): Boolean
+  def remove(key: Array[Byte]): Boolean
 }
 
-trait DeleteStore {
-  def remove(key: Array[Byte]) : Boolean
-}
-
-trait Store extends ReadStore with WriteStore with DeleteStore
+trait Store extends ReadStore with WriteStore

--- a/suuchi-core/src/main/scala/in/ashwanthkumar/suuchi/store/Store.scala
+++ b/suuchi-core/src/main/scala/in/ashwanthkumar/suuchi/store/Store.scala
@@ -8,4 +8,8 @@ trait WriteStore {
   def put(key: Array[Byte], value: Array[Byte]): Boolean
 }
 
-trait Store extends ReadStore with WriteStore
+trait DeleteStore {
+  def remove(key: Array[Byte]) : Boolean
+}
+
+trait Store extends ReadStore with WriteStore with DeleteStore

--- a/suuchi-core/src/main/scala/in/ashwanthkumar/suuchi/store/VersionedBy.scala
+++ b/suuchi-core/src/main/scala/in/ashwanthkumar/suuchi/store/VersionedBy.scala
@@ -1,0 +1,15 @@
+package in.ashwanthkumar.suuchi.store
+
+
+import in.ashwanthkumar.suuchi.utils.DateUtils
+
+trait VersionedBy {
+  val versionOrdering: Ordering[Long]
+  def version(key: Array[Byte], value: Array[Byte]) : Long
+}
+
+class ByWriteTimestamp extends VersionedBy with DateUtils {
+  override def version(key: Array[Byte], value: Array[Byte]): Long = now
+  override val versionOrdering: Ordering[Long] = Ordering.Long.reverse
+}
+

--- a/suuchi-core/src/main/scala/in/ashwanthkumar/suuchi/store/VersionedStore.scala
+++ b/suuchi-core/src/main/scala/in/ashwanthkumar/suuchi/store/VersionedStore.scala
@@ -64,7 +64,7 @@ class VersionedStore(store: Store, versionedBy: VersionedBy, numVersions: Int, c
     if(versions.size > numVersions) removeData(key, versions.min)
 
     // Write out the actual data record
-    store.put(dkey(key, versions.max), value)
+    store.put(dkey(key, currentVersion), value)
 
   }
 

--- a/suuchi-core/src/main/scala/in/ashwanthkumar/suuchi/store/VersionedStore.scala
+++ b/suuchi-core/src/main/scala/in/ashwanthkumar/suuchi/store/VersionedStore.scala
@@ -1,0 +1,87 @@
+package in.ashwanthkumar.suuchi.store
+
+import in.ashwanthkumar.suuchi.store.Store
+import in.ashwanthkumar.suuchi.utils.DateUtils
+
+import scala.util.hashing.MurmurHash3
+
+
+object Versions {
+  def fromString(versionString: String) = versionString.split('|').map(_.toLong)
+  def toString(versions: List[Long]) = versions.map(_.toString).mkString("|")
+}
+
+object VersionedStore {
+  val VERSION_PREFIX = "V_"
+  val DATA_PREFIX = "D_"
+  def vkey(key: Array[Byte]) = VERSION_PREFIX.getBytes ++ key
+  def dkey(key: Array[Byte], version: Long) = DATA_PREFIX.getBytes ++ key ++ version.toString.getBytes
+}
+
+class VersionedStore(store: Store, numVersions: Int) extends Store with DeleteStore with DateUtils {
+  import VersionedStore._
+  val SYNC_SLOTS = Array.fill(8192)(new Object)
+
+  override def get(key: Array[Byte]) : Option[Array[Byte]] = {
+    // fetch version record
+    val vRecord = store.get(vkey(key))
+    if(vRecord.isEmpty) None
+    else {
+      val versions = Versions.fromString(new String(vRecord.get))
+      get(key, versions.max)
+    }
+  }
+
+  def get(key: Array[Byte], version: Long) : Option[Array[Byte]] = {
+    store.get(dkey(key, version))
+  }
+
+  override def put(key: Array[Byte], value: Array[Byte]): Boolean = {
+    val nowMs = now
+
+    // atomically update version metadata
+    val versions = atomicUpdate(key, nowMs)
+
+    // remove oldest version, if we've exceeded max # of versions per record
+    if(versions.size > numVersions) removeData(key, versions.min)
+
+    // Write out the actual data record
+    store.put(dkey(key, versions.max), value)
+
+  }
+
+  def atomicUpdate(key: Array[Byte], version: Long) = {
+    val versionKey = vkey(key)
+    val absHash = math.abs(MurmurHash3.arrayHash(versionKey))
+    // Synchronizing the version metadata update part alone
+    val monitor = SYNC_SLOTS(absHash % SYNC_SLOTS.length)
+    val versions  = monitor.synchronized {
+      val vRecord = store.get(versionKey)
+      val updatedVersions = vRecord.map(bytes => version :: Versions.fromString(new String(bytes)).toList).getOrElse(List(version))
+      // write version record
+      store.put(versionKey, Versions.toString(updatedVersions.take(numVersions)).getBytes)
+      updatedVersions
+    }
+    versions
+  }
+
+  def remove(key: Array[Byte]) = {
+    val versions = getVersions(key)
+    removeVersion(key)
+    versions.foreach(v => removeData(key, v))
+    true
+  }
+
+  private def removeData(key: Array[Byte], version: Long) = store.remove(dkey(key, version))
+  private def removeVersion(key: Array[Byte]) = store.remove(vkey(key))
+
+  private[store] def getVersions(key: Array[Byte]): List[Long] = {
+    val vRecord = store.get(vkey(key))
+    vRecord
+      .map(vr => Versions.fromString(new String(vr)).toList)
+      .getOrElse(List.empty[Long])
+  }
+}
+
+
+

--- a/suuchi-core/src/main/scala/in/ashwanthkumar/suuchi/store/VersionedStore.scala
+++ b/suuchi-core/src/main/scala/in/ashwanthkumar/suuchi/store/VersionedStore.scala
@@ -98,6 +98,3 @@ class VersionedStore(store: Store, versionedBy: VersionedBy, numVersions: Int, c
       .getOrElse(List.empty[Long])
   }
 }
-
-
-

--- a/suuchi-core/src/main/scala/in/ashwanthkumar/suuchi/utils/DateUtils.scala
+++ b/suuchi-core/src/main/scala/in/ashwanthkumar/suuchi/utils/DateUtils.scala
@@ -1,0 +1,7 @@
+package in.ashwanthkumar.suuchi.utils
+
+import org.joda.time.DateTime
+
+trait DateUtils {
+  def now = DateTime.now().getMillis
+}

--- a/suuchi-core/src/test/scala/in/ashwanthkumar/suuchi/store/PrimitivesSerDeUtilsSpec.scala
+++ b/suuchi-core/src/test/scala/in/ashwanthkumar/suuchi/store/PrimitivesSerDeUtilsSpec.scala
@@ -1,0 +1,20 @@
+package in.ashwanthkumar.suuchi.store
+
+import org.scalatest.FlatSpec
+import org.scalatest.Matchers._
+
+class PrimitivesSerDeUtilsSpec extends FlatSpec {
+  "PrimitivesSerDe" should "perform serde on long as expected" in {
+    PrimitivesSerDeUtils.bytesToLong(PrimitivesSerDeUtils.longToBytes(100l)) should be(100l)
+    PrimitivesSerDeUtils.bytesToLong(PrimitivesSerDeUtils.longToBytes(-100l)) should be(-100l)
+    PrimitivesSerDeUtils.bytesToLong(PrimitivesSerDeUtils.longToBytes(Long.MaxValue)) should be(Long.MaxValue)
+    PrimitivesSerDeUtils.bytesToLong(PrimitivesSerDeUtils.longToBytes(Long.MinValue)) should be(Long.MinValue)
+  }
+
+  it should "perform serde on int as expected" in {
+    PrimitivesSerDeUtils.bytesToInt(PrimitivesSerDeUtils.intToBytes(100)) should be(100)
+    PrimitivesSerDeUtils.bytesToInt(PrimitivesSerDeUtils.intToBytes(-100)) should be(-100)
+    PrimitivesSerDeUtils.bytesToInt(PrimitivesSerDeUtils.intToBytes(Int.MaxValue)) should be(Int.MaxValue)
+    PrimitivesSerDeUtils.bytesToInt(PrimitivesSerDeUtils.intToBytes(Int.MinValue)) should be(Int.MinValue)
+  }
+}

--- a/suuchi-core/src/test/scala/in/ashwanthkumar/suuchi/store/VersionedStoreSpec.scala
+++ b/suuchi-core/src/test/scala/in/ashwanthkumar/suuchi/store/VersionedStoreSpec.scala
@@ -12,14 +12,16 @@ trait MockDateUtils extends DateUtils {
   }
 }
 
+object ByWriteTimestampMocked extends ByWriteTimestamp with MockDateUtils
+
 class VersionedStoreSpec extends FlatSpec {
   "VersionedStore" should "return no version info for a key for the first time" in {
-    val store = new VersionedStore(new InMemoryStore, 3)
+    val store = new VersionedStore(new InMemoryStore, ByWriteTimestampMocked, 3)
     store.getVersions(Array(1.toByte)).size should be(0)
   }
 
   it should "return version info appropriately after every insert" in {
-    val store = new VersionedStore(new InMemoryStore, 3) with MockDateUtils
+    val store = new VersionedStore(new InMemoryStore, ByWriteTimestampMocked, 3)
     store.getVersions(Array(1.toByte)).size should be(0)
 
     store.put(Array(1.toByte), Array(100.toByte))
@@ -37,7 +39,7 @@ class VersionedStoreSpec extends FlatSpec {
 
   it should "delete old versions of data for a key when we exceed numVersions" in {
     val inMemoryStore = new InMemoryStore
-    val store = new VersionedStore(inMemoryStore, 3) with MockDateUtils
+    val store = new VersionedStore(inMemoryStore, ByWriteTimestampMocked, 3)
     store.getVersions(Array(1.toByte)).size should be(0)
 
     store.put(Array(1.toByte), Array(100.toByte))

--- a/suuchi-core/src/test/scala/in/ashwanthkumar/suuchi/store/VersionedStoreSpec.scala
+++ b/suuchi-core/src/test/scala/in/ashwanthkumar/suuchi/store/VersionedStoreSpec.scala
@@ -11,17 +11,16 @@ trait MockDateUtils extends DateUtils {
     cnt
   }
 }
-
-object ByWriteTimestampMocked extends ByWriteTimestamp with MockDateUtils
+class ByWriteTimestampMocked extends ByWriteTimestamp with MockDateUtils
 
 class VersionedStoreSpec extends FlatSpec {
   "VersionedStore" should "return no version info for a key for the first time" in {
-    val store = new VersionedStore(new InMemoryStore, ByWriteTimestampMocked, 3)
+    val store = new VersionedStore(new InMemoryStore, new ByWriteTimestampMocked, 3)
     store.getVersions(Array(1.toByte)).size should be(0)
   }
 
   it should "return version info appropriately after every insert" in {
-    val store = new VersionedStore(new InMemoryStore, ByWriteTimestampMocked, 3)
+    val store = new VersionedStore(new InMemoryStore, new ByWriteTimestampMocked, 3)
     store.getVersions(Array(1.toByte)).size should be(0)
 
     store.put(Array(1.toByte), Array(100.toByte))
@@ -39,7 +38,7 @@ class VersionedStoreSpec extends FlatSpec {
 
   it should "delete old versions of data for a key when we exceed numVersions" in {
     val inMemoryStore = new InMemoryStore
-    val store = new VersionedStore(inMemoryStore, ByWriteTimestampMocked, 3)
+    val store = new VersionedStore(inMemoryStore, new ByWriteTimestampMocked, 3)
     store.getVersions(Array(1.toByte)).size should be(0)
 
     store.put(Array(1.toByte), Array(100.toByte))

--- a/suuchi-core/src/test/scala/in/ashwanthkumar/suuchi/store/VersionedStoreSpec.scala
+++ b/suuchi-core/src/test/scala/in/ashwanthkumar/suuchi/store/VersionedStoreSpec.scala
@@ -1,0 +1,55 @@
+package in.ashwanthkumar.suuchi.store
+
+import in.ashwanthkumar.suuchi.utils.DateUtils
+import org.scalatest.FlatSpec
+import org.scalatest.Matchers._
+
+trait MockDateUtils extends DateUtils {
+  var cnt = 0
+  override def now: Long = {
+    cnt += 1
+    cnt
+  }
+}
+
+class VersionedStoreSpec extends FlatSpec {
+  "VersionedStore" should "return no version info for a key for the first time" in {
+    val store = new VersionedStore(new InMemoryStore, 3)
+    store.getVersions(Array(1.toByte)).size should be(0)
+  }
+
+  it should "return version info appropriately after every insert" in {
+    val store = new VersionedStore(new InMemoryStore, 3) with MockDateUtils
+    store.getVersions(Array(1.toByte)).size should be(0)
+
+    store.put(Array(1.toByte), Array(100.toByte))
+    store.getVersions(Array(1.toByte)) should be(List(1))
+
+    store.put(Array(1.toByte), Array(101.toByte))
+    store.getVersions(Array(1.toByte)) should be(List(2, 1))
+
+    store.put(Array(1.toByte), Array(102.toByte))
+    store.getVersions(Array(1.toByte)) should be(List(3, 2, 1))
+
+    store.put(Array(1.toByte), Array(103.toByte))
+    store.getVersions(Array(1.toByte)) should be(List(4,3,2))
+  }
+
+  it should "delete old versions of data for a key when we exceed numVersions" in {
+    val inMemoryStore = new InMemoryStore
+    val store = new VersionedStore(inMemoryStore, 3) with MockDateUtils
+    store.getVersions(Array(1.toByte)).size should be(0)
+
+    store.put(Array(1.toByte), Array(100.toByte))
+    store.getVersions(Array(1.toByte)) should be(List(1))
+
+    store.put(Array(1.toByte), Array(101.toByte))
+    store.getVersions(Array(1.toByte)) should be(List(2, 1))
+
+    store.put(Array(1.toByte), Array(102.toByte))
+    store.getVersions(Array(1.toByte)) should be(List(3, 2, 1))
+
+    store.put(Array(1.toByte), Array(103.toByte))
+    inMemoryStore.get(VersionedStore.dkey(Array(1.toByte), 1)) should be(None)
+  }
+}

--- a/suuchi-core/src/test/scala/in/ashwanthkumar/suuchi/store/VersionsSpec.scala
+++ b/suuchi-core/src/test/scala/in/ashwanthkumar/suuchi/store/VersionsSpec.scala
@@ -1,0 +1,16 @@
+package in.ashwanthkumar.suuchi.store
+
+import org.scalatest.FlatSpec
+import org.scalatest.Matchers.{convertToAnyShouldWrapper, be}
+
+import scala.util.Random
+
+class VersionsSpec extends FlatSpec {
+  "Versions" should "do long serde properly" in {
+    val a = Random.nextLong()
+    val b = Random.nextLong()
+
+    val serialised = Versions.toBytes(List(a, b))
+    Versions.fromBytes(serialised) should be(List(a, b))
+  }
+}

--- a/suuchi-core/src/test/scala/in/ashwanthkumar/suuchi/store/VersionsSpec.scala
+++ b/suuchi-core/src/test/scala/in/ashwanthkumar/suuchi/store/VersionsSpec.scala
@@ -6,7 +6,7 @@ import org.scalatest.Matchers.{convertToAnyShouldWrapper, be}
 import scala.util.Random
 
 class VersionsSpec extends FlatSpec {
-  "Versions" should "do long serde properly" in {
+  "Versions" should "do List[Long] SerDe properly" in {
     val a = Random.nextLong()
     val b = Random.nextLong()
 

--- a/suuchi-rocksdb/src/main/scala/in/ashwanthkumar/suuchi/store/rocksdb/RocksDbStore.scala
+++ b/suuchi-rocksdb/src/main/scala/in/ashwanthkumar/suuchi/store/rocksdb/RocksDbStore.scala
@@ -29,7 +29,6 @@ class RocksDbStore(config: RocksDbConfiguration) extends Store with Logging {
   }
 
   override def remove(key: Array[Byte]): Boolean = {
-    db.remove(key)
-    true
+    Try(db.remove(key)).isSuccess
   }
 }

--- a/suuchi-rocksdb/src/main/scala/in/ashwanthkumar/suuchi/store/rocksdb/RocksDbStore.scala
+++ b/suuchi-rocksdb/src/main/scala/in/ashwanthkumar/suuchi/store/rocksdb/RocksDbStore.scala
@@ -4,6 +4,7 @@ import in.ashwanthkumar.suuchi.store.Store
 import in.ashwanthkumar.suuchi.utils.Logging
 import org.rocksdb._
 
+import scala.language.postfixOps
 import scala.util.Try
 
 class RocksDbStore(config: RocksDbConfiguration) extends Store with Logging {
@@ -20,7 +21,7 @@ class RocksDbStore(config: RocksDbConfiguration) extends Store with Logging {
   }
 
   override def put(key: Array[Byte], value: Array[Byte]) = this.synchronized {
-    Try(db.put(writeOptions, key, value)).isSuccess
+    logOnError(() => db.put(writeOptions, key, value)) isSuccess
   }
 
   def close() = {
@@ -29,6 +30,16 @@ class RocksDbStore(config: RocksDbConfiguration) extends Store with Logging {
   }
 
   override def remove(key: Array[Byte]): Boolean = {
-    Try(db.remove(key)).isSuccess
+    logOnError(() => db.remove(key)) isSuccess
+  }
+
+  def logOnError[T](f: () => T): Try[T] = {
+    Try {
+      f()
+    } recover {
+      case e: Exception =>
+        log.error(e.getMessage, e)
+        throw e
+    }
   }
 }

--- a/suuchi-rocksdb/src/main/scala/in/ashwanthkumar/suuchi/store/rocksdb/RocksDbStore.scala
+++ b/suuchi-rocksdb/src/main/scala/in/ashwanthkumar/suuchi/store/rocksdb/RocksDbStore.scala
@@ -27,4 +27,9 @@ class RocksDbStore(config: RocksDbConfiguration) extends Store with Logging {
     log.info(s"[Closing RocksDb]")
     db.close()
   }
+
+  override def remove(key: Array[Byte]): Boolean = {
+    db.remove(key)
+    true
+  }
 }


### PR DESCRIPTION
Added a versioned store that wraps around any suuchi.Store implementation and provides versioning support for keys
Differentiates Version records & Actual data records with a prefix so that scans for versions (if need be) can be sped up
Explicitly made this project source/target to be java 1.8

@ashwanthkumar Please take a look. 
