### PR TITLE
Pluggable replicator

### DIFF
--- a/suuchi-core/src/main/scala/in/ashwanthkumar/suuchi/router/ReplicationRouter.scala
+++ b/suuchi-core/src/main/scala/in/ashwanthkumar/suuchi/router/ReplicationRouter.scala
@@ -136,7 +136,7 @@ object ParallelReplicator {
   /**
    * Default Executor that can be used along with [[ParallelReplicator]]
    */
-  implicit val PARALLEL_REPLICATION_EXECUTOR = Executors.newCachedThreadPool()
+  implicit val Implicit = Executors.newCachedThreadPool()
 }
 
 /**

--- a/suuchi-core/src/main/scala/in/ashwanthkumar/suuchi/rpc/Server.scala
+++ b/suuchi-core/src/main/scala/in/ashwanthkumar/suuchi/rpc/Server.scala
@@ -1,9 +1,10 @@
 package in.ashwanthkumar.suuchi.rpc
 
 import java.net.InetAddress
+import java.util.concurrent.Executor
 
 import in.ashwanthkumar.suuchi.membership.MemberAddress
-import in.ashwanthkumar.suuchi.router.{HandleOrForwardRouter, RoutingStrategy, SequentialReplicator}
+import in.ashwanthkumar.suuchi.router._
 import io.grpc.{Server => GServer, _}
 import org.slf4j.LoggerFactory
 
@@ -27,12 +28,93 @@ class Server[T <: ServerBuilder[T]](serverBuilder: ServerBuilder[T], whoami: Mem
     })
   }
 
-  def withReplication(service: BindableService, nrOfReplica: Int, strategy: RoutingStrategy) = {
+  /**
+   * Enable a custom [[ReplicationRouter]] implementation for replicating requests to this service. [[RoutingStrategy]]
+   * defines the list of nodes we should replicate the request too.
+   *
+   * @param service Service to which we should hook into for replication.
+   *                Generally these're Write services.
+   * @param replicator [[ReplicationRouter]] implementation that does the actual replication
+   * @param strategy  [[RoutingStrategy]] for deciding what nodes we should replicate to
+   * @return  this object for chaining
+   */
+  def withReplication(service: ServerServiceDefinition, replicator: ReplicationRouter, strategy: RoutingStrategy): Server[T] = {
     val router = new HandleOrForwardRouter(strategy, whoami)
-    // FIXME - make the Replicator pluggable
-    val replicator = new SequentialReplicator(nrOfReplica, whoami)
     serverBuilder.addService(ServerInterceptors.interceptForward(service, router, replicator))
     this
+  }
+
+  /**
+   * Enable a custom [[ReplicationRouter]] implementation for replicating requests to this service. [[RoutingStrategy]]
+   * defines the list of nodes we should replicate the request too.
+   *
+   * @param service Service to which we should hook into for replication.
+   *                Generally these're Write services.
+   * @param replicator [[ReplicationRouter]] implementation that does the actual replication
+   * @param strategy  [[RoutingStrategy]] for deciding what nodes we should replicate to
+   * @return  this object for chaining
+   */
+  def withReplication(service: BindableService, replicator: ReplicationRouter, strategy: RoutingStrategy): Server[T] = {
+    withReplication(service.bindService(), replicator, strategy)
+  }
+
+  /**
+   * Enable [[SequentialReplicator]] for replicating requests to this service. [[RoutingStrategy]]
+   * defines the list of nodes we should replicate the request too.
+   *
+   * @param service Service to which we should hook into for replication.
+   *                Generally these're Write services.
+   * @param nrReplicas  Number of replicas to make for each request
+   * @param strategy  [[RoutingStrategy]] for deciding what nodes we should replicate to
+   * @return  this object for chaining
+   */
+  def withSequentialReplication(service: ServerServiceDefinition, nrReplicas: Int, strategy: RoutingStrategy): Server[T] = {
+    withReplication(service, new SequentialReplicator(nrReplicas, whoami), strategy)
+  }
+
+  /**
+   * Enable [[SequentialReplicator]] for replicating requests to this service. [[RoutingStrategy]]
+   * defines the list of nodes we should replicate the request too.
+   *
+   * @param service Service to which we should hook into for replication.
+   *                Generally these're Write services.
+   * @param nrReplicas  Number of replicas to make for each request
+   * @param strategy  [[RoutingStrategy]] for deciding what nodes we should replicate to
+   * @return  this object for chaining
+   */
+  def withSequentialReplication(service: BindableService, nrReplicas: Int, strategy: RoutingStrategy): Server[T] = {
+    withSequentialReplication(service.bindService(), nrReplicas, strategy)
+  }
+
+  /**
+   * Enable [[ParallelReplicator]] for replicating requets to this service. [[RoutingStrategy]]
+   * defines the list of nodes we should replicate the request too.
+   *
+   * @param service Service to which we should hook into for replication.
+   *                Generally these're Write services.
+   * @param nrReplicas  Number of replicas to make for each request
+   * @param strategy  [[RoutingStrategy]] for deciding what nodes we should replicate to
+   * @return  this object for chaining
+   * @return
+   */
+  def withParallelReplication(service: ServerServiceDefinition, nrReplicas: Int, strategy: RoutingStrategy)
+                             (implicit executor: Executor): Server[T] = {
+    withReplication(service, new ParallelReplicator(nrReplicas, whoami), strategy)
+  }
+
+  /**
+   * Enable [[ParallelReplicator]] for replicating requets to this service. [[RoutingStrategy]]
+   * defines the list of nodes we should replicate the request too.
+   *
+   * @param service Service to which we should hook into for replication.
+   *                Generally these're Write services.
+   * @param nrReplicas  Number of replicas to make for each request
+   * @param strategy  [[RoutingStrategy]] for deciding what nodes we should replicate to
+   * @return  this object for chaining
+   */
+  def withParallelReplication(service: BindableService, nrReplicas: Int, strategy: RoutingStrategy)
+                             (implicit executor: Executor): Server[T] = {
+    withParallelReplication(service.bindService(), nrReplicas, strategy)
   }
 
   def routeUsing(service: BindableService, strategy: RoutingStrategy): Server[T] = routeUsing(service.bindService(), strategy)

--- a/suuchi-core/src/test/scala/in/ashwanthkumar/suuchi/router/ParallelReplicatorSpec.scala
+++ b/suuchi-core/src/test/scala/in/ashwanthkumar/suuchi/router/ParallelReplicatorSpec.scala
@@ -10,7 +10,7 @@ import org.mockito.Matchers._
 import org.mockito.Mockito._
 import org.scalatest.{BeforeAndAfter, FlatSpec}
 
-class MockParallelReplicator(nrReplicas: Int, self: MemberAddress, mock: ParallelReplicator) extends ParallelReplicator(nrReplicas, self) {
+class MockParallelReplicator(nrReplicas: Int, self: MemberAddress, mock: ParallelReplicator)(implicit executor: Executor) extends ParallelReplicator(nrReplicas, self) {
   override def forwardAsync[RespT, ReqT](methodDescriptor: MethodDescriptor[ReqT, RespT], headers: Metadata,
                                          incomingRequest: ReqT, destination: MemberAddress)
                                         (implicit executor: Executor) : ListenableFuture[RespT] = {

--- a/suuchi-examples/src/main/scala/in/ashwanthkumar/suuchi/example/ExampleApp.scala
+++ b/suuchi-examples/src/main/scala/in/ashwanthkumar/suuchi/example/ExampleApp.scala
@@ -12,19 +12,19 @@ object ExampleApp extends App {
   val store1 = new InMemoryStore
   val server1 = Server(NettyServerBuilder.forPort(5051), whoami(5051))
     .routeUsing(new SuuchiReadService(store1), routingStrategy)
-    .withReplication(new SuuchiPutService(store1), 2, routingStrategy)
+    .withSequentialReplication(new SuuchiPutService(store1), 2, routingStrategy)
   server1.start()
 
   val store2 = new InMemoryStore
   val server2 = Server(NettyServerBuilder.forPort(5052), whoami(5052))
     .routeUsing(new SuuchiReadService(store2), routingStrategy)
-    .withReplication(new SuuchiPutService(store2), 2, routingStrategy)
+    .withSequentialReplication(new SuuchiPutService(store2), 2, routingStrategy)
   server2.start()
 
   val store3 = new InMemoryStore
   val server3 = Server(NettyServerBuilder.forPort(5053), whoami(5053))
     .routeUsing(new SuuchiReadService(store3), routingStrategy)
-    .withReplication(new SuuchiPutService(store3), 2, routingStrategy)
+    .withSequentialReplication(new SuuchiPutService(store3), 2, routingStrategy)
   server3.start()
 
   server1.blockUntilShutdown()

--- a/suuchi-examples/src/main/scala/in/ashwanthkumar/suuchi/example/ExampleApp.scala
+++ b/suuchi-examples/src/main/scala/in/ashwanthkumar/suuchi/example/ExampleApp.scala
@@ -8,6 +8,8 @@ import io.grpc.netty.NettyServerBuilder
 
 // Start the app with either / one each of 5051, 5052 or/and 5053 port numbers
 object ExampleApp extends App {
+  import in.ashwanthkumar.suuchi.router.ParallelReplicator.Implicit
+
   val port = args(0).toInt
   val replication = 2
 


### PR DESCRIPTION
Fixes #40 
- replaced the old withReplication() to withSequentialReplication and withParallelReplication
- withReplication now takes ReplicationRouter as an argument and can be used by developers to plug in custom replicator implementation

@brewkode Please check this out. 
