### PR TITLE
Fixing Routing bug

### DIFF
--- a/suuchi-core/src/main/scala/in/ashwanthkumar/suuchi/router/RoutingStrategy.scala
+++ b/suuchi-core/src/main/scala/in/ashwanthkumar/suuchi/router/RoutingStrategy.scala
@@ -25,16 +25,16 @@ object RoutingStrategy {
 
 /**
  * Always forward the requests to a given node - useful in tests or while debugging
- * @param memberAddress
+ * @param members
  */
-class AlwaysRouteTo(memberAddress: MemberAddress) extends RoutingStrategy {
+class AlwaysRouteTo(members: MemberAddress*) extends RoutingStrategy {
   private val log = LoggerFactory.getLogger(getClass)
   /**
    * @inheritdoc
    */
   override def route[ReqT]: PartialFunction[ReqT, List[MemberAddress]] = {
     case msg: RoutingStrategy.WithKey =>
-      List(memberAddress)
+      members.toList
   }
 }
 

--- a/suuchi-examples/src/main/scala/in/ashwanthkumar/suuchi/example/ExampleApp.scala
+++ b/suuchi-examples/src/main/scala/in/ashwanthkumar/suuchi/example/ExampleApp.scala
@@ -6,28 +6,18 @@ import in.ashwanthkumar.suuchi.rpc.{Server, SuuchiPutService, SuuchiReadService}
 import in.ashwanthkumar.suuchi.store.InMemoryStore
 import io.grpc.netty.NettyServerBuilder
 
+// Start the app with either / one each of 5051, 5052 or/and 5053 port numbers
 object ExampleApp extends App {
-  val routingStrategy = ConsistentHashingRouting(2, whoami(5051), whoami(5052), whoami(5053))
+  val port = args(0).toInt
+  val replication = 2
 
-  val store1 = new InMemoryStore
-  val server1 = Server(NettyServerBuilder.forPort(5051), whoami(5051))
-    .routeUsing(new SuuchiReadService(store1), routingStrategy)
-    .withReplication(new SuuchiPutService(store1), 2, routingStrategy)
-  server1.start()
+  val routingStrategy = ConsistentHashingRouting(replication, whoami(5051), whoami(5052), whoami(5053))
 
-  val store2 = new InMemoryStore
-  val server2 = Server(NettyServerBuilder.forPort(5052), whoami(5052))
-    .routeUsing(new SuuchiReadService(store2), routingStrategy)
-    .withReplication(new SuuchiPutService(store2), 2, routingStrategy)
-  server2.start()
+  val store = new InMemoryStore
+  val server = Server(NettyServerBuilder.forPort(port), whoami(port))
+    .routeUsing(new SuuchiReadService(store), routingStrategy)
+    .withReplication(new SuuchiPutService(store), replication, routingStrategy)
+  server.start()
 
-  val store3 = new InMemoryStore
-  val server3 = Server(NettyServerBuilder.forPort(5053), whoami(5053))
-    .routeUsing(new SuuchiReadService(store3), routingStrategy)
-    .withReplication(new SuuchiPutService(store3), 2, routingStrategy)
-  server3.start()
-
-  server1.blockUntilShutdown()
-  server2.blockUntilShutdown()
-  server3.blockUntilShutdown()
+  server.blockUntilShutdown()
 }


### PR DESCRIPTION
Today we don't re-try on forward failures. Assume we've 3 nodes - A,B and C. Client has done some puts and with replication of 2, the data is distributed and replicated between all the 3 nodes. Assume now A goes down. We should still be able to serve all requests from other nodes in the cluster because of replication.

This change would make sure we re-try all the nodes until one of them succeeds else we would return FAILED_PRECONDITION response to the client.

Credits to @codingnirvana for helping me discover this bug. 
