### PR TITLE
Sharded store

### DIFF
--- a/suuchi-core/src/main/scala/in/ashwanthkumar/suuchi/store/ShardedStore.scala
+++ b/suuchi-core/src/main/scala/in/ashwanthkumar/suuchi/store/ShardedStore.scala
@@ -1,0 +1,53 @@
+package in.ashwanthkumar.suuchi.store
+
+import java.util.concurrent.ConcurrentHashMap
+
+import in.ashwanthkumar.suuchi.partitioner.Hash
+import in.ashwanthkumar.suuchi.utils.Logging
+
+/**
+ * SharedStore shards the keys equally into [[partitionsPerNode]] stores and proxies store operations
+ * against them for a given key.
+ * <p/>
+ *
+ * DO NOT CHANGE THE [[hashFn]] and [[partitionsPerNode]] on an existing store,
+ * we wouldn't be able to read previously hashed keys.
+ *
+ * TODO - May be build a tool that can migrate between the shards (hashes and number)
+ * by doing a full scan of the underlying store and re-creating the data.
+ *
+ * @param partitionsPerNode Number of stores we need to shard the data into
+ * @param hashFn  HashFunction used to compute the shard
+ * @param createStore  Function to return a store instance given a partitionId.
+ *                     This would be created in the form [1 -> partitionsPerNode].
+ *                     Take care to not throw exceptions in this method. If it does,
+ *                     we propagate that error back to the service who invoked us.
+ */
+class ShardedStore(partitionsPerNode: Int, hashFn: Hash, createStore: (Int) => Store) extends Store with Logging {
+  private val map = new ConcurrentHashMap[Integer, Store](partitionsPerNode)
+
+  private val locks = Array.fill(partitionsPerNode)(new Object)
+
+  override def get(key: Array[Byte]): Option[Array[Byte]] = logOnError(() => getStore(key).get(key)).getOrElse(None)
+  override def put(key: Array[Byte], value: Array[Byte]): Boolean = logOnError(() => getStore(key).put(key, value)).isSuccess
+  override def remove(key: Array[Byte]): Boolean = logOnError(() => getStore(key).remove(key)).isSuccess
+
+  private def getStore(key: Array[Byte]): Store = {
+    val partition = hashFn.hash(key) % partitionsPerNode
+    if (map.containsKey(partition)) {
+      map.get(partition)
+    } else {
+      locks(partition).synchronized {
+        // To trade off between locks for most of the code path and consistency in not invoking `createStore`
+        // unless absolutely we need it.
+        if (!map.containsKey(partition)) {
+          val store = logOnError(() => createStore(partition)).get
+          map.put(partition, store)
+          store
+        } else {
+          map.get(partition)
+        }
+      }
+    }
+  }
+}

--- a/suuchi-core/src/main/scala/in/ashwanthkumar/suuchi/utils/Logging.scala
+++ b/suuchi-core/src/main/scala/in/ashwanthkumar/suuchi/utils/Logging.scala
@@ -2,6 +2,19 @@ package in.ashwanthkumar.suuchi.utils
 
 import org.slf4j.LoggerFactory
 
+import scala.util.Try
+
 trait Logging { self =>
   val log = LoggerFactory.getLogger(this.getClass)
+
+
+  def logOnError[T](f: () => T): Try[T] = {
+    Try {
+      f()
+    } recover {
+      case e: Exception =>
+        log.error(e.getMessage, e)
+        throw e
+    }
+  }
 }

--- a/suuchi-core/src/test/scala/in/ashwanthkumar/suuchi/store/ShardedStoreSpec.scala
+++ b/suuchi-core/src/test/scala/in/ashwanthkumar/suuchi/store/ShardedStoreSpec.scala
@@ -1,0 +1,40 @@
+package in.ashwanthkumar.suuchi.store
+
+import java.nio.ByteBuffer
+
+import in.ashwanthkumar.suuchi.partitioner.Hash
+import org.mockito.Mockito.{mock, times, verify, when}
+import org.scalatest.FlatSpec
+import org.scalatest.Matchers.{be, convertToAnyShouldWrapper}
+
+class ShardedStoreSpec extends FlatSpec {
+  "ShardedStore" should "create 2 stores for 2 different Partitions" in {
+    val hash = mock(classOf[Hash])
+    when(hash.hash("1".getBytes)).thenReturn(1)
+    when(hash.hash("2".getBytes)).thenReturn(2)
+
+    val store1 = mock(classOf[Store])
+    when(store1.get("1".getBytes)).thenReturn(None)
+    val store2 = mock(classOf[Store])
+    when(store2.get("2".getBytes)).thenReturn(Some(Array(Byte.MaxValue)))
+
+    val createStore = mock(classOf[(Int) => Store])
+    when(createStore.apply(1)).thenReturn(store1)
+    when(createStore.apply(2)).thenReturn(store2)
+
+    val shardedStore = new ShardedStore(3, hash, createStore)
+    val response = shardedStore.get("1".getBytes)
+    verify(hash, times(1)).hash("1".getBytes)
+    verify(createStore, times(1)).apply(1)
+    verify(store1, times(1)).get("1".getBytes)
+    response should be(None)
+
+    val response2 = shardedStore.get("2".getBytes)
+    verify(hash, times(1)).hash("2".getBytes)
+    verify(createStore, times(1)).apply(2)
+    verify(store2, times(1)).get("2".getBytes)
+    response2.map(ByteBuffer.wrap) should be(Some(Array(Byte.MaxValue)).map(ByteBuffer.wrap))
+  }
+
+  // TODO - Write tests for the synchronized {} in getStore.
+}

--- a/suuchi-core/src/test/scala/in/ashwanthkumar/suuchi/store/ShardedStoreSpec.scala
+++ b/suuchi-core/src/test/scala/in/ashwanthkumar/suuchi/store/ShardedStoreSpec.scala
@@ -76,5 +76,44 @@ class ShardedStoreSpec extends FlatSpec {
     verify(store, times(1)).remove("1".getBytes)
   }
 
+  it should "return None for store.get when underlying store throws an Exception" in {
+    val hash = mock(classOf[Hash])
+    when(hash.hash("1".getBytes)).thenReturn(1)
+
+    val store = mock(classOf[Store])
+    when(store.get("1".getBytes)).thenThrow(classOf[RuntimeException])
+    val createStore = mock(classOf[(Int) => Store])
+    when(createStore.apply(1)).thenReturn(store)
+
+    val shardedStore = new ShardedStore(3, hash, createStore)
+    shardedStore.get("1".getBytes) should be(None)
+  }
+
+  it should "return false for store.put when underlying store throws an Exception" in {
+    val hash = mock(classOf[Hash])
+    when(hash.hash("1".getBytes)).thenReturn(1)
+
+    val store = mock(classOf[Store])
+    when(store.put("1".getBytes, "2".getBytes)).thenThrow(classOf[RuntimeException])
+    val createStore = mock(classOf[(Int) => Store])
+    when(createStore.apply(1)).thenReturn(store)
+
+    val shardedStore = new ShardedStore(3, hash, createStore)
+    shardedStore.put("1".getBytes, "2".getBytes) should be(false)
+  }
+
+  it should "return false for store.remove when underlying store throws an Exception" in {
+    val hash = mock(classOf[Hash])
+    when(hash.hash("1".getBytes)).thenReturn(1)
+
+    val store = mock(classOf[Store])
+    when(store.remove("1".getBytes)).thenThrow(classOf[RuntimeException])
+    val createStore = mock(classOf[(Int) => Store])
+    when(createStore.apply(1)).thenReturn(store)
+
+    val shardedStore = new ShardedStore(3, hash, createStore)
+    shardedStore.remove("1".getBytes) should be(false)
+  }
+
   // TODO - Write tests for the synchronized {} in getStore.
 }

--- a/suuchi-rocksdb/src/main/scala/in/ashwanthkumar/suuchi/store/rocksdb/RocksDbStore.scala
+++ b/suuchi-rocksdb/src/main/scala/in/ashwanthkumar/suuchi/store/rocksdb/RocksDbStore.scala
@@ -5,7 +5,6 @@ import in.ashwanthkumar.suuchi.utils.Logging
 import org.rocksdb._
 
 import scala.language.postfixOps
-import scala.util.Try
 
 class RocksDbStore(config: RocksDbConfiguration) extends Store with Logging {
   lazy val db = {
@@ -31,15 +30,5 @@ class RocksDbStore(config: RocksDbConfiguration) extends Store with Logging {
 
   override def remove(key: Array[Byte]): Boolean = {
     logOnError(() => db.remove(key)) isSuccess
-  }
-
-  def logOnError[T](f: () => T): Try[T] = {
-    Try {
-      f()
-    } recover {
-      case e: Exception =>
-        log.error(e.getMessage, e)
-        throw e
-    }
   }
 }


### PR DESCRIPTION
For some use-cases where we can't have one large database (like RocksDB) for storing multi-terrabyte data. It would be great to have sharding of the `Store` and a wrapper store that manages it for us automatically. 

`ShardedStore` extends Store, so it's a drop-in replacement for all of the existing stores and you would start having multiple shards automatically. If the existing store already has some data, they might have to be re-played or converted to the newer format. I would have written a tool for migration but since we still don't expose the `scan` interface on store, it's not possible to write a generic utility that can do this for us.

@brewkode Please check this out. 
