### PR TITLE
Ash/Selva - Added full and prefix scan support to all the stores

### DIFF
--- a/suuchi-core/src/main/proto/suuchi.proto
+++ b/suuchi-core/src/main/proto/suuchi.proto
@@ -67,7 +67,7 @@ message ScanRequest {
     int32 end = 2;
 }
 message ScanResponse {
-    KV iterator = 1;
+    KV kv = 1;
 }
 message KV {
     bytes key = 1;

--- a/suuchi-core/src/main/proto/suuchi.proto
+++ b/suuchi-core/src/main/proto/suuchi.proto
@@ -58,3 +58,18 @@ message Node {
     string host = 1;
     int32 port = 2;
 }
+
+service SuuchiScan {
+    rpc Scan (ScanRequest) returns (stream ScanResponse);
+}
+message ScanRequest {
+    int32 start = 1;
+    int32 end = 2;
+}
+message ScanResponse {
+    KV iterator = 1;
+}
+message KV {
+    bytes key = 1;
+    bytes value = 2;
+}

--- a/suuchi-core/src/main/scala/in/ashwanthkumar/suuchi/partitioner/ConsistentHashRing.scala
+++ b/suuchi-core/src/main/scala/in/ashwanthkumar/suuchi/partitioner/ConsistentHashRing.scala
@@ -144,16 +144,6 @@ class ConsistentHashRing(hashFn: Hash, partitionsPerNode: Int, replicationFactor
     }
   }
 
-  private[partitioner] def findCandidate(hash: Integer) = {
-    if (sortedMap.containsKey(hash)) {
-      hash -> sortedMap.get(hash).node
-    } else {
-      val tailMap = sortedMap.tailMap(hash)
-      val newHash = if (tailMap.isEmpty) sortedMap.firstKey() else tailMap.firstKey()
-      newHash -> sortedMap.get(newHash).node
-    }
-  }
-
   /**
    * Represent the ConsistentHashRing as [[RingState]] which is more easier to work with in terms of Ranges that each node manages.
    *
@@ -167,6 +157,16 @@ class ConsistentHashRing(hashFn: Hash, partitionsPerNode: Int, replicationFactor
       RingState(token, ranges = TokenRange(state.lastKnown, token - 1, sortedMap.get(state.lastKnown)) :: state.ranges)
     }
     RingState(Int.MaxValue, ranges = (TokenRange(tokenRings.lastKnown, firstToken - 1, sortedMap.get(tokenRings.lastKnown)) :: tokenRings.ranges).reverse)
+  }
+
+  private[partitioner] def findCandidate(hash: Integer) = {
+    if (sortedMap.containsKey(hash)) {
+      hash -> sortedMap.get(hash).node
+    } else {
+      val tailMap = sortedMap.tailMap(hash)
+      val newHash = if (tailMap.isEmpty) sortedMap.firstKey() else tailMap.firstKey()
+      newHash -> sortedMap.get(newHash).node
+    }
   }
 
   // USED ONLY FOR TESTS

--- a/suuchi-core/src/main/scala/in/ashwanthkumar/suuchi/partitioner/ConsistentHashRing.scala
+++ b/suuchi-core/src/main/scala/in/ashwanthkumar/suuchi/partitioner/ConsistentHashRing.scala
@@ -3,6 +3,7 @@ package in.ashwanthkumar.suuchi.partitioner
 import java.util
 
 import in.ashwanthkumar.suuchi.cluster.MemberAddress
+import in.ashwanthkumar.suuchi.utils.ByteArrayUtils
 
 import scala.annotation.tailrec
 import scala.collection.mutable
@@ -38,9 +39,7 @@ object RingState {
     *         false otherwise
     */
   def contains(key: Array[Byte], start: Int, end: Int, hashFn: Hash): Boolean = {
-    val hash = hashFn.hash(key)
-
-    start <= hash && hash <= end
+    ByteArrayUtils.isHashKeyWithinRange(start, end, key, hashFn)
   }
 }
 

--- a/suuchi-core/src/main/scala/in/ashwanthkumar/suuchi/rpc/SuuchiScanService.scala
+++ b/suuchi-core/src/main/scala/in/ashwanthkumar/suuchi/rpc/SuuchiScanService.scala
@@ -19,7 +19,7 @@ class SuuchiScanService(store: Store) extends SuuchiScanGrpc.SuuchiScanImplBase 
 
   private def buildResponse(response: KV): ScanResponse = {
     SuuchiRPC.ScanResponse.newBuilder()
-      .setIterator(buildKV(response))
+      .setKv(buildKV(response))
       .build()
   }
 

--- a/suuchi-core/src/main/scala/in/ashwanthkumar/suuchi/rpc/SuuchiScanService.scala
+++ b/suuchi-core/src/main/scala/in/ashwanthkumar/suuchi/rpc/SuuchiScanService.scala
@@ -10,13 +10,6 @@ import io.grpc.stub.{ServerCallStreamObserver, StreamObserver}
 
 class SuuchiScanService(store: Store) extends SuuchiScanGrpc.SuuchiScanImplBase {
 
-  private def buildKV(kv: KV) = {
-    SuuchiRPC.KV.newBuilder()
-      .setKey(ByteString.copyFrom(kv.key))
-      .setValue(ByteString.copyFrom(kv.value))
-      .build()
-  }
-
   private def buildResponse(response: KV): ScanResponse = {
     SuuchiRPC.ScanResponse.newBuilder()
       .setKv(buildKV(response))
@@ -35,5 +28,12 @@ class SuuchiScanService(store: Store) extends SuuchiScanGrpc.SuuchiScanImplBase 
         observer.onNext(buildResponse(response))
     }
     observer.onCompleted()
+  }
+
+  private def buildKV(kv: KV) = {
+    SuuchiRPC.KV.newBuilder()
+      .setKey(ByteString.copyFrom(kv.key))
+      .setValue(ByteString.copyFrom(kv.value))
+      .build()
   }
 }

--- a/suuchi-core/src/main/scala/in/ashwanthkumar/suuchi/rpc/SuuchiScanService.scala
+++ b/suuchi-core/src/main/scala/in/ashwanthkumar/suuchi/rpc/SuuchiScanService.scala
@@ -1,0 +1,39 @@
+package in.ashwanthkumar.suuchi.rpc
+
+import com.google.protobuf.ByteString
+import in.ashwanthkumar.suuchi.partitioner.SuuchiHash
+import in.ashwanthkumar.suuchi.rpc.generated.SuuchiRPC.{ScanRequest, ScanResponse}
+import in.ashwanthkumar.suuchi.rpc.generated.{SuuchiRPC, SuuchiScanGrpc}
+import in.ashwanthkumar.suuchi.store.{KV, Store}
+import in.ashwanthkumar.suuchi.utils.ByteArrayUtils
+import io.grpc.stub.{ServerCallStreamObserver, StreamObserver}
+
+class SuuchiScanService(store: Store) extends SuuchiScanGrpc.SuuchiScanImplBase {
+
+  private def buildKV(kv: KV) = {
+    SuuchiRPC.KV.newBuilder()
+      .setKey(ByteString.copyFrom(kv.key))
+      .setValue(ByteString.copyFrom(kv.value))
+      .build()
+  }
+
+  private def buildResponse(response: KV): ScanResponse = {
+    SuuchiRPC.ScanResponse.newBuilder()
+      .setIterator(buildKV(response))
+      .build()
+  }
+
+  override def scan(request: ScanRequest, responseObserver: StreamObserver[ScanResponse]): Unit = {
+    val observer = responseObserver.asInstanceOf[ServerCallStreamObserver[ScanResponse]]
+    val start = request.getStart
+    val end = request.getEnd
+
+    val iterator = store.scan()
+    for(response <- iterator) {
+//      ConnectionUtils.waitForReady(observer) // block until the channel is ready to send messages
+      if (ByteArrayUtils.isHashKeyWithinRange(start, end, response.key, SuuchiHash))
+        observer.onNext(buildResponse(response))
+    }
+    observer.onCompleted()
+  }
+}

--- a/suuchi-core/src/main/scala/in/ashwanthkumar/suuchi/store/InMemoryStore.scala
+++ b/suuchi-core/src/main/scala/in/ashwanthkumar/suuchi/store/InMemoryStore.scala
@@ -1,19 +1,23 @@
 package in.ashwanthkumar.suuchi.store
 
 import java.nio.ByteBuffer
-import java.util.concurrent.ConcurrentHashMap
+import java.util.{Arrays => JArrays}
+import java.util.concurrent.ConcurrentSkipListMap
 
 import org.slf4j.LoggerFactory
 
+import scala.collection.JavaConversions._
+
 class InMemoryStore extends Store {
   private val log = LoggerFactory.getLogger(getClass)
-  private val store = new ConcurrentHashMap[ByteBuffer, Array[Byte]]()
+  private val store = new ConcurrentSkipListMap[ByteBuffer, Array[Byte]]()
 
   override def put(key: Array[Byte], value: Array[Byte]): Boolean = {
     log.trace(s"Put with key=${new String(key)}, value=${new String(value)}")
     store.put(ByteBuffer.wrap(key), value)
     true
   }
+
   override def get(key: Array[Byte]): Option[Array[Byte]] = {
     log.trace(s"Get with key=${new String(key)}")
     val value = Option(store.get(ByteBuffer.wrap(key)))
@@ -25,5 +29,20 @@ class InMemoryStore extends Store {
     log.trace(s"Remove for key=${new String(key)}")
     store.remove(ByteBuffer.wrap(key))
     true
+  }
+
+  override def scan(): Iterator[KV] = {
+    store.entrySet().map(kv => KV(kv.getKey.array(), kv.getValue)).iterator
+  }
+
+  private def hasPrefix(key: Array[Byte], prefix: Array[Byte]) = {
+    key.length >= prefix.length && JArrays.equals(key.take(prefix.length), prefix)
+  }
+
+  override def scan(prefix: Array[Byte]): Iterator[KV] = {
+    store.tailMap(ByteBuffer.wrap(prefix))
+      .takeWhile{case (k, v) => hasPrefix(k.array(), prefix)}
+      .map{case (k, v) => KV(k.array(), v)}
+      .iterator
   }
 }

--- a/suuchi-core/src/main/scala/in/ashwanthkumar/suuchi/store/InMemoryStore.scala
+++ b/suuchi-core/src/main/scala/in/ashwanthkumar/suuchi/store/InMemoryStore.scala
@@ -4,6 +4,7 @@ import java.nio.ByteBuffer
 import java.util.{Arrays => JArrays}
 import java.util.concurrent.ConcurrentSkipListMap
 
+import in.ashwanthkumar.suuchi.utils.ByteArrayUtils
 import org.slf4j.LoggerFactory
 
 import scala.collection.JavaConversions._
@@ -35,13 +36,9 @@ class InMemoryStore extends Store {
     store.entrySet().map(kv => KV(kv.getKey.array(), kv.getValue)).iterator
   }
 
-  private def hasPrefix(key: Array[Byte], prefix: Array[Byte]) = {
-    key.length >= prefix.length && JArrays.equals(key.take(prefix.length), prefix)
-  }
-
   override def scan(prefix: Array[Byte]): Iterator[KV] = {
     store.tailMap(ByteBuffer.wrap(prefix))
-      .takeWhile{case (k, v) => hasPrefix(k.array(), prefix)}
+      .takeWhile{case (k, v) => ByteArrayUtils.hasPrefix(k.array(), prefix)}
       .map{case (k, v) => KV(k.array(), v)}
       .iterator
   }

--- a/suuchi-core/src/main/scala/in/ashwanthkumar/suuchi/store/ShardedStore.scala
+++ b/suuchi-core/src/main/scala/in/ashwanthkumar/suuchi/store/ShardedStore.scala
@@ -5,6 +5,8 @@ import java.util.concurrent.ConcurrentHashMap
 import in.ashwanthkumar.suuchi.partitioner.Hash
 import in.ashwanthkumar.suuchi.utils.Logging
 
+import scala.collection.JavaConversions._
+
 /**
  * SharedStore shards the keys equally into [[partitionsPerNode]] stores and proxies store operations
  * against them for a given key.
@@ -50,4 +52,8 @@ class ShardedStore(partitionsPerNode: Int, hashFn: Hash, createStore: (Int) => S
       }
     }
   }
+
+  override def scan(): Iterator[KV] = map.values().flatMap(_.scan()).iterator
+
+  override def scan(prefix: Array[Byte]): Iterator[KV] = map.values().flatMap(_.scan(prefix)).iterator
 }

--- a/suuchi-core/src/main/scala/in/ashwanthkumar/suuchi/store/Store.scala
+++ b/suuchi-core/src/main/scala/in/ashwanthkumar/suuchi/store/Store.scala
@@ -16,8 +16,6 @@ case class KV(key: Array[Byte], value: Array[Byte]) {
     case o: KV => util.Arrays.equals(key, o.key) && util.Arrays.equals(value, o.value)
     case _ => false
   }
-
-  override def toString: String = new String(key) + " " + new String(value)
 }
 trait Scannable {
   def scan(): Iterator[KV]

--- a/suuchi-core/src/main/scala/in/ashwanthkumar/suuchi/store/Store.scala
+++ b/suuchi-core/src/main/scala/in/ashwanthkumar/suuchi/store/Store.scala
@@ -1,5 +1,7 @@
 package in.ashwanthkumar.suuchi.store
 
+import java.util
+
 trait ReadStore {
   def get(key: Array[Byte]): Option[Array[Byte]]
 }
@@ -9,4 +11,17 @@ trait WriteStore {
   def remove(key: Array[Byte]): Boolean
 }
 
-trait Store extends ReadStore with WriteStore
+case class KV(key: Array[Byte], value: Array[Byte]) {
+  override def equals(obj: scala.Any): Boolean = obj match {
+    case o: KV => util.Arrays.equals(key, o.key) && util.Arrays.equals(value, o.value)
+    case _ => false
+  }
+
+  override def toString: String = new String(key) + " " + new String(value)
+}
+trait Scannable {
+  def scan(): Iterator[KV]
+  def scan(prefix: Array[Byte]): Iterator[KV]
+}
+
+trait Store extends ReadStore with WriteStore with Scannable

--- a/suuchi-core/src/main/scala/in/ashwanthkumar/suuchi/store/VersionedStore.scala
+++ b/suuchi-core/src/main/scala/in/ashwanthkumar/suuchi/store/VersionedStore.scala
@@ -37,6 +37,7 @@ object VersionedStore {
 
   def isDataKey(key: Array[Byte]) = util.Arrays.equals(key.take(DATA_PREFIX.length), DATA_PREFIX)
   def vkey(key: Array[Byte]) = VERSION_PREFIX ++ key
+  def dkey(key: Array[Byte]): Array[Byte] = DATA_PREFIX ++ key
   def dkey(key: Array[Byte], version: Array[Byte]): Array[Byte] = DATA_PREFIX ++ key ++ version
   def dkey(key: Array[Byte], version: Long): Array[Byte] = DATA_PREFIX ++ key ++ PrimitivesSerDeUtils.longToBytes(version)
 }
@@ -113,5 +114,5 @@ class VersionedStore(store: Store, versionedBy: VersionedBy, numVersions: Int, c
 
   override def scan(): Iterator[KV] = store.scan().filter(kv => VersionedStore.isDataKey(kv.key))
 
-  override def scan(prefix: Array[Byte]): Iterator[KV] = store.scan(prefix).filter(kv => VersionedStore.isDataKey(kv.key))
+  override def scan(prefix: Array[Byte]): Iterator[KV] = store.scan(dkey(prefix))
 }

--- a/suuchi-core/src/main/scala/in/ashwanthkumar/suuchi/utils/ByteArrayUtils.scala
+++ b/suuchi-core/src/main/scala/in/ashwanthkumar/suuchi/utils/ByteArrayUtils.scala
@@ -1,0 +1,9 @@
+package in.ashwanthkumar.suuchi.utils
+
+import java.util.{Arrays => JArrays}
+
+object ByteArrayUtils {
+  def hasPrefix(bytes: Array[Byte], prefix: Array[Byte]): Boolean = {
+    bytes.length >= prefix.length && JArrays.equals(bytes.take(prefix.length), prefix)
+  }
+}

--- a/suuchi-core/src/main/scala/in/ashwanthkumar/suuchi/utils/ByteArrayUtils.scala
+++ b/suuchi-core/src/main/scala/in/ashwanthkumar/suuchi/utils/ByteArrayUtils.scala
@@ -2,8 +2,16 @@ package in.ashwanthkumar.suuchi.utils
 
 import java.util.{Arrays => JArrays}
 
+import in.ashwanthkumar.suuchi.partitioner.Hash
+
 object ByteArrayUtils {
   def hasPrefix(bytes: Array[Byte], prefix: Array[Byte]): Boolean = {
     bytes.length >= prefix.length && JArrays.equals(bytes.take(prefix.length), prefix)
+  }
+
+  def isHashKeyWithinRange(start: Int, end: Int, key: Array[Byte], hashFn: Hash) = {
+    val hash = hashFn.hash(key)
+
+    start <= hash && hash <= end
   }
 }

--- a/suuchi-core/src/test/scala/in/ashwanthkumar/suuchi/rpc/SuuchiScanServiceTest.scala
+++ b/suuchi-core/src/test/scala/in/ashwanthkumar/suuchi/rpc/SuuchiScanServiceTest.scala
@@ -1,0 +1,64 @@
+package in.ashwanthkumar.suuchi.rpc
+
+import in.ashwanthkumar.suuchi.rpc.generated.SuuchiRPC.{ScanRequest, ScanResponse}
+import in.ashwanthkumar.suuchi.store.{InMemoryStore, Store}
+import io.grpc.stub.ServerCallStreamObserver
+import org.mockito.ArgumentCaptor
+import org.mockito.Mockito._
+import org.scalatest.FlatSpec
+import org.scalatest.Matchers.{be, convertToAnyShouldWrapper, have}
+
+import scala.collection.JavaConversions._
+
+class SuuchiScanServiceTest extends FlatSpec {
+
+  private def populateStore(num: Int, store: Store) = 1 to num foreach (i => store.put(i.toString.getBytes, (i * 100).toString.getBytes))
+
+  private def extractKey(response: ScanResponse) = new String(response.getIterator.getKey.toByteArray).toInt
+
+  "SuuchiScanService" should "support scan for a given token range" in {
+
+    val store = new InMemoryStore
+    lazy val service = new SuuchiScanService(store)
+
+    val request = ScanRequest.newBuilder()
+      .setStart(Integer.MIN_VALUE)
+      .setEnd(Integer.MAX_VALUE)
+      .build()
+
+    populateStore(10, store)
+
+    val observer = mock(classOf[ServerCallStreamObserver[ScanResponse]])
+    val captor = ArgumentCaptor.forClass(classOf[ScanResponse])
+    val values = captor.getAllValues
+
+    service.scan(request, observer)
+
+    verify(observer, times(10)).onNext(captor.capture())
+    verify(observer, times(1)).onCompleted()
+    values should have size 10
+    values.toList.map(extractKey).toSet should be(1 to 10 toSet)
+  }
+
+  it should "not include key which are out of the given toekn range" in {
+    val store = new InMemoryStore
+    lazy val service = new SuuchiScanService(store)
+
+    val request = ScanRequest.newBuilder()
+      .setStart(1)
+      .setEnd(10)
+      .build()
+
+    populateStore(10, store)
+
+    val observer = mock(classOf[ServerCallStreamObserver[ScanResponse]])
+    val captor = ArgumentCaptor.forClass(classOf[ScanResponse])
+    val values = captor.getAllValues
+
+    service.scan(request, observer)
+
+    verify(observer, times(0)).onNext(captor.capture())
+    verify(observer, times(1)).onCompleted()
+  }
+
+}

--- a/suuchi-core/src/test/scala/in/ashwanthkumar/suuchi/rpc/SuuchiScanServiceTest.scala
+++ b/suuchi-core/src/test/scala/in/ashwanthkumar/suuchi/rpc/SuuchiScanServiceTest.scala
@@ -14,7 +14,7 @@ class SuuchiScanServiceTest extends FlatSpec {
 
   private def populateStore(num: Int, store: Store) = 1 to num foreach (i => store.put(i.toString.getBytes, (i * 100).toString.getBytes))
 
-  private def extractKey(response: ScanResponse) = new String(response.getIterator.getKey.toByteArray).toInt
+  private def extractKey(response: ScanResponse) = new String(response.getKv.getKey.toByteArray).toInt
 
   "SuuchiScanService" should "support scan for a given token range" in {
 

--- a/suuchi-core/src/test/scala/in/ashwanthkumar/suuchi/store/InMemoryStoreTest.scala
+++ b/suuchi-core/src/test/scala/in/ashwanthkumar/suuchi/store/InMemoryStoreTest.scala
@@ -1,7 +1,7 @@
 package in.ashwanthkumar.suuchi.store
 
 import org.scalatest.FlatSpec
-import org.scalatest.Matchers.{be, convertToAnyShouldWrapper}
+import org.scalatest.Matchers.{be, convertToAnyShouldWrapper, have, startWith}
 
 class InMemoryStoreTest extends FlatSpec {
   "InMemoryStore" should "support get and put on a KV" in {
@@ -9,4 +9,35 @@ class InMemoryStoreTest extends FlatSpec {
     store.put("1".getBytes, "2".getBytes) should be(true)
     store.get("1".getBytes).map(v => new String(v)) should be(Some("2"))
   }
+
+  it should "support full store scan" in {
+    val store = new InMemoryStore
+    store.put("1".getBytes, "one".getBytes)
+    store.put("2".getBytes, "two".getBytes)
+    store.put("3".getBytes, "three".getBytes)
+    store.put("4".getBytes, "four".getBytes)
+    store.put("5".getBytes, "five".getBytes)
+
+    val kVs = store.scan().toList
+    kVs should have size 5
+    kVs.sortBy(kv => new String(kv.key)) should be(List(kv("1", "one"), kv("2", "two"), kv("3", "three"), kv("4", "four"), kv("5", "five")))
+  }
+
+  it should "support prefix scan" in {
+    val store = new InMemoryStore
+    store.put("prefix1/1".getBytes, "one".getBytes)
+    store.put("prefix1/2".getBytes, "two".getBytes)
+    store.put("prefix1/3".getBytes, "three".getBytes)
+    store.put("prefix2/1".getBytes, "eleven".getBytes)
+    store.put("prefix2/2".getBytes, "twelve".getBytes)
+    store.put("prefix2/3".getBytes, "thirteen".getBytes)
+
+    val kVs = store.scan("prefix1".getBytes).toList
+
+    kVs.foreach{kv =>
+      new String(kv.key) should startWith("prefix1")
+    }
+  }
+
+  def kv(key: String, value: String) = KV(key.getBytes, value.getBytes)
 }

--- a/suuchi-core/src/test/scala/in/ashwanthkumar/suuchi/store/ShardedStoreSpec.scala
+++ b/suuchi-core/src/test/scala/in/ashwanthkumar/suuchi/store/ShardedStoreSpec.scala
@@ -54,7 +54,7 @@ class ShardedStoreSpec extends FlatSpec {
     verify(store, times(1)).put("2".getBytes, "3".getBytes)
   }
 
-  it should "call get / put / remove on the delegate store when corresponding methods are called" in {
+  it should "call get / put / remove / scan / scan with prefix on the delegate store when corresponding methods are called" in {
     val hash = mock(classOf[Hash])
     when(hash.hash("1".getBytes)).thenReturn(1)
 
@@ -62,6 +62,8 @@ class ShardedStoreSpec extends FlatSpec {
     when(store.get("1".getBytes)).thenReturn(None)
     when(store.put("1".getBytes, "2".getBytes)).thenReturn(true)
     when(store.remove("1".getBytes)).thenReturn(true)
+    when(store.scan()).thenReturn(Iterator.empty)
+    when(store.scan("1".getBytes)).thenReturn(Iterator.empty)
 
     val createStore = mock(classOf[(Int) => Store])
     when(createStore.apply(1)).thenReturn(store)
@@ -70,10 +72,14 @@ class ShardedStoreSpec extends FlatSpec {
     shardedStore.get("1".getBytes) should be(None)
     shardedStore.put("1".getBytes, "2".getBytes) should be(true)
     shardedStore.remove("1".getBytes) should be(true)
+    shardedStore.scan().toList should be(List.empty)
+    shardedStore.scan("1".getBytes).toList should be(List.empty)
 
     verify(store, times(1)).get("1".getBytes)
     verify(store, times(1)).put("1".getBytes, "2".getBytes)
     verify(store, times(1)).remove("1".getBytes)
+    verify(store, times(1)).scan()
+    verify(store, times(1)).scan("1".getBytes)
   }
 
   it should "return None for store.get when underlying store throws an Exception" in {

--- a/suuchi-core/src/test/scala/in/ashwanthkumar/suuchi/utils/ByteArrayUtilsSpec.scala
+++ b/suuchi-core/src/test/scala/in/ashwanthkumar/suuchi/utils/ByteArrayUtilsSpec.scala
@@ -30,9 +30,12 @@ class ByteArrayUtilsSpec extends FlatSpec {
     val hashFn = mock(classOf[Hash])
     val key = "1".getBytes
 
-    when(hashFn.hash(key)).thenReturn(1).thenReturn(100)
+    when(hashFn.hash(key)).thenReturn(1)
 
     ByteArrayUtils.isHashKeyWithinRange(10, 100, key, hashFn) should be(false)
+
+    when(hashFn.hash(key)).thenReturn(100)
+
     ByteArrayUtils.isHashKeyWithinRange(1, 10, key, hashFn) should be(false)
   }
 

--- a/suuchi-core/src/test/scala/in/ashwanthkumar/suuchi/utils/ByteArrayUtilsSpec.scala
+++ b/suuchi-core/src/test/scala/in/ashwanthkumar/suuchi/utils/ByteArrayUtilsSpec.scala
@@ -6,10 +6,13 @@ import org.scalatest.Matchers._
 class ByteArrayUtilsSpec extends FlatSpec {
 
   "ByteArrayUtils" should "say whether a given byte array starts with a specified byte array prefix" in {
-    ByteArrayUtils.hasPrefix("string".getBytes, prefix = "longerString".getBytes) should be(false)
     ByteArrayUtils.hasPrefix("string".getBytes, prefix = "char".getBytes) should be(false)
     ByteArrayUtils.hasPrefix("string".getBytes, prefix = "str".getBytes) should be(true)
     ByteArrayUtils.hasPrefix("string".getBytes, prefix = "string".getBytes) should be(true)
+  }
+
+  it should "return false when the given prefix is longer than the key" in {
+    ByteArrayUtils.hasPrefix("string".getBytes, prefix = "longerString".getBytes) should be(false)
   }
 
 }

--- a/suuchi-core/src/test/scala/in/ashwanthkumar/suuchi/utils/ByteArrayUtilsSpec.scala
+++ b/suuchi-core/src/test/scala/in/ashwanthkumar/suuchi/utils/ByteArrayUtilsSpec.scala
@@ -1,7 +1,9 @@
 package in.ashwanthkumar.suuchi.utils
 
+import in.ashwanthkumar.suuchi.partitioner.{Hash, SuuchiHash}
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers._
+import org.mockito.Mockito._
 
 class ByteArrayUtilsSpec extends FlatSpec {
 
@@ -13,6 +15,25 @@ class ByteArrayUtilsSpec extends FlatSpec {
 
   it should "return false when the given prefix is longer than the key" in {
     ByteArrayUtils.hasPrefix("string".getBytes, prefix = "longerString".getBytes) should be(false)
+  }
+
+  it should "return true if hash of the given key within start, end range" in {
+    val hashFn = mock(classOf[Hash])
+    val key = "1".getBytes
+
+    when(hashFn.hash(key)).thenReturn(10)
+
+    ByteArrayUtils.isHashKeyWithinRange(1, 50, key, hashFn) should be(true)
+  }
+
+  it should "return false if hash of the given key is not within start, end range" in {
+    val hashFn = mock(classOf[Hash])
+    val key = "1".getBytes
+
+    when(hashFn.hash(key)).thenReturn(1).thenReturn(100)
+
+    ByteArrayUtils.isHashKeyWithinRange(10, 100, key, hashFn) should be(false)
+    ByteArrayUtils.isHashKeyWithinRange(1, 10, key, hashFn) should be(false)
   }
 
 }

--- a/suuchi-core/src/test/scala/in/ashwanthkumar/suuchi/utils/ByteArrayUtilsSpec.scala
+++ b/suuchi-core/src/test/scala/in/ashwanthkumar/suuchi/utils/ByteArrayUtilsSpec.scala
@@ -1,0 +1,15 @@
+package in.ashwanthkumar.suuchi.utils
+
+import org.scalatest.FlatSpec
+import org.scalatest.Matchers._
+
+class ByteArrayUtilsSpec extends FlatSpec {
+
+  "ByteArrayUtils" should "say whether a given byte array starts with a specified byte array prefix" in {
+    ByteArrayUtils.hasPrefix("string".getBytes, prefix = "longerString".getBytes) should be(false)
+    ByteArrayUtils.hasPrefix("string".getBytes, prefix = "char".getBytes) should be(false)
+    ByteArrayUtils.hasPrefix("string".getBytes, prefix = "str".getBytes) should be(true)
+    ByteArrayUtils.hasPrefix("string".getBytes, prefix = "string".getBytes) should be(true)
+  }
+
+}

--- a/suuchi-rocksdb/src/main/scala/in/ashwanthkumar/suuchi/store/rocksdb/RocksDbStore.scala
+++ b/suuchi-rocksdb/src/main/scala/in/ashwanthkumar/suuchi/store/rocksdb/RocksDbStore.scala
@@ -3,7 +3,7 @@ package in.ashwanthkumar.suuchi.store.rocksdb
 import java.util.{Arrays => JArrays}
 
 import in.ashwanthkumar.suuchi.store.{KV, Store}
-import in.ashwanthkumar.suuchi.utils.Logging
+import in.ashwanthkumar.suuchi.utils.{ByteArrayUtils, Logging}
 import org.rocksdb._
 
 import scala.language.postfixOps
@@ -40,19 +40,15 @@ class RocksDbStore(config: RocksDbConfiguration) extends Store with Logging {
     val rocksIterator: RocksIterator = db.newIterator()
     rocksIterator.seek(prefix)
 
-    val iterator = new Iterator[KV] {
-      override def hasNext: Boolean = rocksIterator.isValid && hasPrefix(rocksIterator.key(), prefix)
+    new Iterator[KV] {
+      override def hasNext: Boolean = rocksIterator.isValid && ByteArrayUtils.hasPrefix(rocksIterator.key(), prefix)
+
       override def next(): KV = {
         val kv = KV(rocksIterator.key(), rocksIterator.value())
         rocksIterator.next()
         kv
       }
-
-      private def hasPrefix(key: Array[Byte], prefix: Array[Byte]) = {
-        key.length >= prefix.length && JArrays.equals(key.take(prefix.length), prefix)
-      }
     }
-    iterator
   }
 
 }

--- a/suuchi-rocksdb/src/test/scala/in/ashwanthkumar/suuchi/store/rocksdb/RocksDbStoreSpec.scala
+++ b/suuchi-rocksdb/src/test/scala/in/ashwanthkumar/suuchi/store/rocksdb/RocksDbStoreSpec.scala
@@ -2,22 +2,28 @@ package in.ashwanthkumar.suuchi.store.rocksdb
 
 import java.io.File
 
+import in.ashwanthkumar.suuchi.store.KV
 import org.apache.commons.io.FileUtils
-import org.scalatest.Matchers._
+import org.scalatest.Matchers.{be, convertToAnyShouldWrapper, have, startWith}
 import org.scalatest.{BeforeAndAfter, FlatSpec}
 
 class RocksDbStoreSpec extends FlatSpec with BeforeAndAfter {
-  val ROCKSDB_TEST_LOCATION = "/tmp/suuchi-rocks-test"
+
+  val ROCKSDB_TEST_LOCATION = "/tmp/suuchi-rocks-test/"
+
+  var db: RocksDbStore = _
+
   before {
     FileUtils.deleteDirectory(new File(ROCKSDB_TEST_LOCATION))
+    db = new RocksDbStore(RocksDbConfiguration.apply(ROCKSDB_TEST_LOCATION))
   }
 
   after {
     FileUtils.deleteDirectory(new File(ROCKSDB_TEST_LOCATION))
+    db.close()
   }
 
   "RocksDb" should "store & retrieve results properly" in {
-    val db = new RocksDbStore(RocksDbConfiguration.apply(ROCKSDB_TEST_LOCATION))
     (1 to 100).foreach { i =>
       db.put(Array(i toByte), Array(i*2 toByte))
     }
@@ -25,6 +31,27 @@ class RocksDbStoreSpec extends FlatSpec with BeforeAndAfter {
     (1 to 100).foreach { i =>
       db.get(Array(i toByte)).get.head should be(i*2 toByte)
     }
+  }
 
+  it should "support full db scan" in {
+    val inputKVs = (1 to 100).map(i => (Array(i toByte), Array(i*2 toByte)))
+
+    inputKVs.foreach{case (k, v) => db.put(k, v)}
+    val scannedResult = db.scan().toList
+
+    scannedResult should have size 100
+    scannedResult.sortBy(kv => new String(kv.key)) should be(inputKVs.map{case (k,v) => KV(k, v)}.toList)
+  }
+
+  it should "support prefix scan" in {
+    val kVs = (1 to 100).flatMap(i => List((s"prefix1/$i".getBytes, Array(i toByte)), (s"prefix2/$i".getBytes, Array(i * 2 toByte))))
+
+    kVs.foreach{case (k, v) => db.put(k, v)}
+    val scannedResult = db.scan("prefix1".getBytes).toList
+
+    scannedResult should have size 100
+    scannedResult.foreach{ kv =>
+      new String(kv.key) should startWith("prefix1")
+    }
   }
 }


### PR DESCRIPTION
Changed ConcurrentHashMap of InMemoryStore to ConcurrentSkipListMap to preserve ordering of keys

Added tests to RocksDB and InMemory stores.

@gsriram7 Creating a PR out of the branch - so it's easy to track the work we do and review changes easily. 