### PR TITLE
sbt, grpc, scala: bump versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,14 +7,8 @@ import java.util.Date
 import Dependencies._
 import sbt.Keys._
 import sbt.Package.ManifestAttributes
-import sbt.SbtExclusionRule
 
-
-ivyScala := ivyScala.value map {
-  _.copy(overrideScalaVersion = true)
-}
-
-val scalaV = "2.11.11"
+val scalaV = "2.11.12"
 val gitRevision = Try(Process("git rev-parse HEAD").!!.stripLineEnd).getOrElse("?").trim.take(6)
 
 lazy val core = (project in file("suuchi-core"))
@@ -76,14 +70,14 @@ lazy val buildInfoSettings = Seq(
   )
 )
 
-lazy val projectSettings = net.virtualvoid.sbt.graph.Plugin.graphSettings ++ Seq(
+lazy val projectSettings = Seq(
   organization := "in.ashwanthkumar",
   scalaVersion := scalaV,
   resolvers += Resolver.mavenLocal,
   excludeDependencies ++= Seq(
-    SbtExclusionRule("cglib", "cglib-nodep"),
-    SbtExclusionRule("commons-beanutils", "commons-beanutils"),
-    SbtExclusionRule("commons-beanutils", "commons-beanutils-core")
+    ExclusionRule("cglib", "cglib-nodep"),
+    ExclusionRule("commons-beanutils", "commons-beanutils"),
+    ExclusionRule("commons-beanutils", "commons-beanutils-core")
   ),
   parallelExecution in ThisBuild := false,
   scalacOptions ++= Seq("-unchecked",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,7 +11,7 @@ object Dependencies {
   val hocon     = "com.typesafe" % "config"     % "1.2.1"
   val commonsIO = "commons-io"   % "commons-io" % "2.5"
 
-  val grpcVersion  = "1.2.0"
+  val grpcVersion  = "1.23.0"
   val grpcNetty    = "io.grpc" % "grpc-netty" % grpcVersion
   val grpcStub     = "io.grpc" % "grpc-stub" % grpcVersion
   val grpcCore     = "io.grpc" % "grpc-core" % grpcVersion
@@ -20,15 +20,15 @@ object Dependencies {
   val grpcTesting  = "io.grpc" % "grpc-testing" % grpcVersion % Test
   val grpc         = Seq(grpcNetty, grpcStub, grpcCore, grpcProtobuf, grpcServices, grpcTesting)
 
-  val nettyVersion   = "4.1.8.Final"
+  val nettyVersion   = "4.1.38.Final"
   val nettyCodec     = "io.netty" % "netty-codec" % nettyVersion
   val nettyCommon    = "io.netty" % "netty-common" % nettyVersion
   val nettyTransport = "io.netty" % "netty-transport" % nettyVersion
   val nettyHandler   = "io.netty" % "netty-handler" % nettyVersion
   val netty          = Seq(nettyCodec, nettyCommon, nettyTransport, nettyHandler)
 
-  val sbProtoRuntime = "com.trueaccord.scalapb" %% "scalapb-runtime" % com.trueaccord.scalapb.compiler.Version.scalapbVersion
-  val sbGrpcRuntime  = "com.trueaccord.scalapb" %% "scalapb-runtime-grpc" % com.trueaccord.scalapb.compiler.Version.scalapbVersion
+  val sbProtoRuntime = "com.thesamet.scalapb" %% "scalapb-runtime" % scalapb.compiler.Version.scalapbVersion
+  val sbGrpcRuntime  = "com.thesamet.scalapb" %% "scalapb-runtime-grpc" % scalapb.compiler.Version.scalapbVersion
   val scalaPB        = Seq(sbProtoRuntime, sbGrpcRuntime)
 
   val slf4j = "org.slf4j" % "slf4j-api" % "1.7.12"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.11
+sbt.version = 1.2.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,11 +1,11 @@
-addSbtPlugin("com.github.sbt" % "sbt-jacoco" % "3.0.3")
+addSbtPlugin("com.github.sbt" % "sbt-jacoco" % "3.2.0")
 
-addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.7.5")
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.2")
 
-addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.7.0")
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")
 
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.6")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.11")
 
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.6")
 
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.0")

--- a/project/protoc.sbt
+++ b/project/protoc.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.12")
+addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.25")
 
-libraryDependencies += "com.trueaccord.scalapb" %% "compilerplugin" % "0.6.6"
+libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.9.1"


### PR DESCRIPTION
Hi, is this project maintained? I wanted to bump few versions but some help would be needed.
Grpc has different testing helpers api now. Also seems there might be some Guava binary incompatibility found in the tests.